### PR TITLE
provider: add claude-cli backend

### DIFF
--- a/internal/provider/claude.go
+++ b/internal/provider/claude.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -19,10 +20,10 @@ type Claude struct {
 	timeout time.Duration
 }
 
-// NewClaude creates a new Claude CLI provider.
-func NewClaude() *Claude {
+// NewClaude creates a new Claude CLI provider with the given timeout.
+func NewClaude(timeout time.Duration) *Claude {
 	return &Claude{
-		timeout: 30 * time.Second,
+		timeout: timeout,
 	}
 }
 
@@ -32,13 +33,22 @@ func (c *Claude) Chat(ctx context.Context, messages []Message) (string, error) {
 	ctx, cancel := context.WithTimeout(ctx, c.timeout)
 	defer cancel()
 
-	input := buildClaudeInput(messages)
+	systemPrompt, userInput := buildClaudeInput(messages)
 
-	cmd := exec.CommandContext(ctx, "claude", "-p", "--output-format", "json")
-	cmd.Stdin = strings.NewReader(input)
+	args := []string{"-p", "--output-format", "json"}
+	if systemPrompt != "" {
+		args = append(args, "--system-prompt", systemPrompt)
+	}
+
+	cmd := exec.CommandContext(ctx, "claude", args...)
+	cmd.Stdin = strings.NewReader(userInput)
 
 	output, err := cmd.Output()
 	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
+			return "", fmt.Errorf("execute claude: %w, stderr: %s", err, exitErr.Stderr)
+		}
 		return "", fmt.Errorf("execute claude: %w", err)
 	}
 
@@ -54,22 +64,25 @@ func (c *Claude) Chat(ctx context.Context, messages []Message) (string, error) {
 	return resp.Result, nil
 }
 
-// buildClaudeInput assembles the conversation into a single prompt string.
-// System messages become context, history provides conversation continuity,
-// and the last user message is the actual question.
-func buildClaudeInput(messages []Message) string {
-	var b strings.Builder
-
-	// Collect system messages as context.
+// buildClaudeInput separates messages into a system prompt and user input.
+// System messages are joined into a single system prompt string.
+// Non-system messages become the user input: history as context, last message as the question.
+func buildClaudeInput(messages []Message) (systemPrompt, userInput string) {
+	var system strings.Builder
 	var history []Message
+
 	for _, m := range messages {
 		if m.Role == "system" {
-			b.WriteString(m.Content)
-			b.WriteString("\n\n")
+			if system.Len() > 0 {
+				system.WriteString("\n\n")
+			}
+			system.WriteString(m.Content)
 		} else {
 			history = append(history, m)
 		}
 	}
+
+	var b strings.Builder
 
 	// Add conversation history.
 	if len(history) > 1 {
@@ -86,5 +99,5 @@ func buildClaudeInput(messages []Message) string {
 		b.WriteString(last.Content)
 	}
 
-	return b.String()
+	return system.String(), b.String()
 }

--- a/internal/provider/claude_test.go
+++ b/internal/provider/claude_test.go
@@ -1,0 +1,88 @@
+package provider
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBuildClaudeInput(t *testing.T) {
+	tests := []struct {
+		name             string
+		messages         []Message
+		wantSystemPrompt string
+		wantUserInput    string
+	}{
+		{
+			name: "single user message",
+			messages: []Message{
+				{Role: "user", Content: "Hello"},
+			},
+			wantSystemPrompt: "",
+			wantUserInput:    "Hello",
+		},
+		{
+			name: "system prompt and user message",
+			messages: []Message{
+				{Role: "system", Content: "You are a helpful assistant."},
+				{Role: "user", Content: "Hello"},
+			},
+			wantSystemPrompt: "You are a helpful assistant.",
+			wantUserInput:    "Hello",
+		},
+		{
+			name: "multiple system messages joined",
+			messages: []Message{
+				{Role: "system", Content: "Be helpful."},
+				{Role: "system", Content: "Be concise."},
+				{Role: "user", Content: "Hello"},
+			},
+			wantSystemPrompt: "Be helpful.\n\nBe concise.",
+			wantUserInput:    "Hello",
+		},
+		{
+			name: "conversation history",
+			messages: []Message{
+				{Role: "system", Content: "You are helpful."},
+				{Role: "user", Content: "Hi"},
+				{Role: "assistant", Content: "Hello!"},
+				{Role: "user", Content: "How are you?"},
+			},
+			wantSystemPrompt: "You are helpful.",
+			wantUserInput:    "Conversation so far:\n[user]: Hi\n[assistant]: Hello!\n\nHow are you?",
+		},
+		{
+			name:             "empty messages",
+			messages:         []Message{},
+			wantSystemPrompt: "",
+			wantUserInput:    "",
+		},
+		{
+			name: "system only",
+			messages: []Message{
+				{Role: "system", Content: "You are helpful."},
+			},
+			wantSystemPrompt: "You are helpful.",
+			wantUserInput:    "",
+		},
+		{
+			name: "timestamps ignored in output",
+			messages: []Message{
+				{Role: "user", Content: "Hello", Timestamp: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)},
+			},
+			wantSystemPrompt: "",
+			wantUserInput:    "Hello",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotSystem, gotInput := buildClaudeInput(tt.messages)
+			if gotSystem != tt.wantSystemPrompt {
+				t.Errorf("systemPrompt:\n got: %q\nwant: %q", gotSystem, tt.wantSystemPrompt)
+			}
+			if gotInput != tt.wantUserInput {
+				t.Errorf("userInput:\n got: %q\nwant: %q", gotInput, tt.wantUserInput)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add `internal/provider/claude.go` — executes `claude -p --output-format json`
- Assembles conversation history as context in stdin (system prompt + history + user message)
- 30s timeout via `context.WithTimeout`

## Test plan
- [ ] `go build ./...` compiles without errors
- [ ] Manual test with `claude` CLI installed: provider returns response

🤖 Generated with [Claude Code](https://claude.com/claude-code)