### PR TITLE
provider: add OpenAI-compatible HTTP backend

### DIFF
--- a/internal/provider/openai.go
+++ b/internal/provider/openai.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
+	"time"
 )
 
 // OpenAI is an OpenAI-compatible HTTP provider.
@@ -27,7 +29,7 @@ func NewOpenAI(name, baseURL, model, apiKey string) *OpenAI {
 		baseURL: baseURL,
 		model:   model,
 		apiKey:  apiKey,
-		client:  &http.Client{},
+		client:  &http.Client{Timeout: 30 * time.Second},
 	}
 }
 
@@ -50,7 +52,7 @@ func (o *OpenAI) Chat(ctx context.Context, messages []Message) (string, error) {
 		return "", fmt.Errorf("marshal request: %w", err)
 	}
 
-	url := o.baseURL + "/chat/completions"
+	url := strings.TrimRight(o.baseURL, "/") + "/chat/completions"
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
 		return "", fmt.Errorf("create request: %w", err)
@@ -64,7 +66,7 @@ func (o *OpenAI) Chat(ctx context.Context, messages []Message) (string, error) {
 	}
 	defer resp.Body.Close()
 
-	respBody, err := io.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
 		return "", fmt.Errorf("read response: %w", err)
 	}


### PR DESCRIPTION
## Summary
- Add `internal/provider/openai.go` — standard HTTP client for OpenAI-compatible APIs
- Configurable base URL, model, and API key
- Works with Chutes.ai, Groq, Gemini, DeepSeek, etc.

## Test plan
- [ ] `go build ./...` compiles without errors
- [ ] Manual test with Chutes.ai API key

🤖 Generated with [Claude Code](https://claude.com/claude-code)