### PR TITLE
provider: add fallback chain

### DIFF
--- a/internal/provider/fallback.go
+++ b/internal/provider/fallback.go
@@ -35,9 +35,17 @@ func (f *Fallback) Name() string {
 }
 
 func (f *Fallback) Chat(ctx context.Context, messages []Message) (string, error) {
+	if len(f.providers) == 0 {
+		return "", fmt.Errorf("no providers configured")
+	}
+
 	var errs []string
 
 	for _, p := range f.providers {
+		if err := ctx.Err(); err != nil {
+			return "", fmt.Errorf("fallback aborted: %w", err)
+		}
+
 		result, err := p.Chat(ctx, messages)
 		if err == nil {
 			f.mu.Lock()


### PR DESCRIPTION
## Summary
- Add `internal/provider/fallback.go` — tries providers in config order, returns first success
- Logs which provider failed and why
- Tracks active provider name for `/status` and `/model` commands

## Test plan
- [ ] `go build ./...` compiles without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)