### PR TITLE
cli: wire everything together in serve command

### DIFF
--- a/cmd/herald/ask.go
+++ b/cmd/herald/ask.go
@@ -12,13 +12,13 @@ import (
 )
 
 func newAskCmd() *cobra.Command {
-	var configPath string
-
-	cmd := &cobra.Command{
+	return &cobra.Command{
 		Use:   "ask [question]",
 		Short: "Ask a question directly (bypass Telegram)",
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			configPath, _ := cmd.Flags().GetString("config")
+
 			cfg, err := config.Load(configPath)
 			if err != nil {
 				return fmt.Errorf("load config: %w", err)
@@ -45,10 +45,6 @@ func newAskCmd() *cobra.Command {
 			return nil
 		},
 	}
-
-	cmd.Flags().StringVarP(&configPath, "config", "c", "config.json", "path to config file")
-
-	return cmd
 }
 
 func buildProviders(cfg *config.Config) []provider.LLMProvider {

--- a/cmd/herald/main.go
+++ b/cmd/herald/main.go
@@ -1,25 +1,93 @@
 package main
 
 import (
+	"context"
 	"fmt"
+	"log"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/spf13/cobra"
+	"github.com/sgraczyk/herald/internal/agent"
+	"github.com/sgraczyk/herald/internal/config"
+	"github.com/sgraczyk/herald/internal/hub"
+	"github.com/sgraczyk/herald/internal/provider"
+	"github.com/sgraczyk/herald/internal/store"
+	"github.com/sgraczyk/herald/internal/telegram"
 )
 
 var version = "dev"
 
 func main() {
+	var configPath string
+
 	root := &cobra.Command{
 		Use:     "herald",
 		Short:   "Lightweight AI assistant bot for Telegram",
 		Version: version,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return serve(configPath)
+		},
+		SilenceUsage: true,
 	}
 
+	root.PersistentFlags().StringVarP(&configPath, "config", "c", "config.json", "path to config file")
 	root.AddCommand(newAskCmd())
 
 	if err := root.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+}
+
+func serve(configPath string) error {
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+
+	if cfg.Telegram.Token == "" {
+		return fmt.Errorf("telegram token not set (env var: %s)", cfg.Telegram.TokenEnv)
+	}
+
+	// Open store.
+	db, err := store.Open(cfg.Store.Path)
+	if err != nil {
+		return fmt.Errorf("open store: %w", err)
+	}
+	defer db.Close()
+
+	// Build providers.
+	providers := buildProviders(cfg)
+	if len(providers) == 0 {
+		return fmt.Errorf("no providers configured")
+	}
+	chain := provider.NewFallback(providers)
+
+	// Create hub.
+	h := hub.New()
+
+	// Create agent loop.
+	loop := agent.NewLoop(h, chain, db, cfg.HistoryLimit)
+
+	// Create Telegram adapter.
+	tg, err := telegram.New(cfg.Telegram.Token, h, cfg.AllowedUserIDs)
+	if err != nil {
+		return fmt.Errorf("create telegram adapter: %w", err)
+	}
+
+	// Graceful shutdown.
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	// Start agent loop.
+	go loop.Run(ctx)
+
+	log.Printf("herald %s starting (provider: %s)", version, chain.Name())
+
+	// Start Telegram (blocks until ctx cancelled).
+	tg.Start(ctx)
+
+	log.Println("herald stopped")
+	return nil
 }


### PR DESCRIPTION
## Summary
- Default command (no subcommand) starts the full Telegram bot
- Wires config → store → providers → hub → agent loop → Telegram adapter
- Graceful shutdown on SIGINT/SIGTERM
- Move `--config` to persistent root flag (shared by `serve` and `ask`)

## Test plan
- [x] `go build ./...` compiles without errors
- [x] `go test ./...` — store tests pass
- [x] Cross-compile: `GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build`
- [ ] `TELEGRAM_TOKEN=xxx ./herald` — bot starts and responds

🤖 Generated with [Claude Code](https://claude.com/claude-code)