### PR TITLE
deploy: add systemd service unit

### DIFF
--- a/herald.service
+++ b/herald.service
@@ -5,6 +5,8 @@ Wants=network-online.target
 
 [Service]
 Type=simple
+User=herald
+Group=herald
 ExecStart=/usr/local/bin/herald --config /etc/herald/config.json
 WorkingDirectory=/var/lib/herald
 EnvironmentFile=/etc/herald/.env
@@ -17,6 +19,8 @@ ProtectSystem=strict
 ProtectHome=true
 ReadWritePaths=/var/lib/herald
 PrivateTmp=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- Add `herald.service` — systemd unit for deployment
- Auto-restart on failure (5s delay)
- Config at `/etc/herald/config.json`, secrets at `/etc/herald/.env`
- Data directory at `/var/lib/herald`
- Basic hardening: NoNewPrivileges, ProtectSystem, ProtectHome

## Test plan
- [ ] Copy to `/etc/systemd/system/herald.service` on target
- [ ] `systemctl daemon-reload && systemctl start herald`
- [ ] Verify bot responds to Telegram messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)