### PR TITLE
ci: add lint and test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version-file: go.mod
       - run: go vet ./...
       - uses: dominikh/staticcheck-action@v1
 
@@ -26,5 +26,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version-file: go.mod
       - run: go test ./...


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI workflow (`.github/workflows/ci.yml`)
- **lint** job: `go vet` + `staticcheck` via `dominikh/staticcheck-action`
- **test** job: `go test ./...`
- Both jobs run in parallel on pushes/PRs to `main` with `CGO_ENABLED=0`

Closes #25

## Test plan
- [ ] Confirm both jobs appear and pass on this PR
- [ ] Verify `setup-go` caches modules correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)