### PR TITLE
ci: add release workflow on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - run: GOOS=linux GOARCH=amd64 go build -o herald-linux-amd64 ./cmd/herald
+      - run: GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w -X main.version=${{ github.ref_name }}" -o herald-linux-amd64 ./cmd/herald
       - uses: softprops/action-gh-release@v2
         with:
           files: herald-linux-amd64


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow that creates a GitHub Release with a prebuilt `linux/amd64` binary when a `v*` tag is pushed
- Uses `softprops/action-gh-release@v2` with auto-generated release notes
- Follows the same patterns as `ci.yml` (checkout, setup-go, CGO_ENABLED=0)

Closes #26

## Test plan

- [ ] Push a test tag (`v0.0.0-test`) to verify the workflow triggers and produces the expected release
- [ ] Verify the attached binary is a valid linux/amd64 ELF executable

🤖 Generated with [Claude Code](https://claude.com/claude-code)