### PR TITLE
ci: add build step and race detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,22 @@ jobs:
       - run: go vet ./...
       - uses: dominikh/staticcheck-action@v1
 
-  test:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - run: go test ./...
+      - run: go build ./cmd/herald
+
+  test:
+    runs-on: ubuntu-latest
+    env:
+      CGO_ENABLED: "1"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - run: go test -race ./...

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,9 +201,9 @@ GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o herald ./cmd/herald
 Two GitHub Actions workflows in `.github/workflows/`:
 
 **CI** (`ci.yml`) — runs on push/PR to `main`:
-- `go vet ./...`
-- `staticcheck` (via `dominikh/staticcheck-action`)
-- `go test ./...`
+- **lint:** `go vet ./...` + `staticcheck` (via `dominikh/staticcheck-action`)
+- **build:** `go build ./cmd/herald` (verifies compilation with `CGO_ENABLED=0`)
+- **test:** `go test -race ./...` (race detector enabled via `CGO_ENABLED=1`)
 
 **Release** (`release.yml`) — runs on tag push (`v*`):
 - Builds `linux/amd64` static binary with `-trimpath -ldflags="-s -w"`


### PR DESCRIPTION
## Summary

Closes #33

- Add `build` job to CI that verifies compilation with `CGO_ENABLED=0`
- Enable race detector on tests (`go test -race ./...`) with `CGO_ENABLED=1` override
- Update AGENTS.md CI/CD section to reflect the new workflow structure

## Test plan

- [ ] All three CI jobs (lint, build, test) pass on this PR
- [ ] Race detector is active in test logs (`-race` flag visible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)