### PR TITLE
provider: enable web search and fetch tools for Claude CLI

### DIFF
--- a/internal/provider/claude.go
+++ b/internal/provider/claude.go
@@ -22,7 +22,7 @@ type Claude struct {
 // NewClaude creates a new Claude CLI provider.
 func NewClaude() *Claude {
 	return &Claude{
-		timeout: 30 * time.Second,
+		timeout: 60 * time.Second,
 	}
 }
 
@@ -34,7 +34,7 @@ func (c *Claude) Chat(ctx context.Context, messages []Message) (string, error) {
 
 	input := buildClaudeInput(messages)
 
-	cmd := exec.CommandContext(ctx, "claude", "-p", "--output-format", "json")
+	cmd := exec.CommandContext(ctx, "claude", "-p", "--output-format", "json", "--allowedTools", "WebSearch,WebFetch")
 	cmd.Stdin = strings.NewReader(input)
 
 	output, err := cmd.Output()


### PR DESCRIPTION
## Summary

- Add `--allowedTools WebSearch,WebFetch` to Claude CLI invocation so Herald can answer questions requiring current information
- Increase timeout from 30s to 60s to accommodate web search latency (~25s observed)

Closes #45

## Test plan

- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [ ] Deploy and verify web search queries return real-time results

🤖 Generated with [Claude Code](https://claude.com/claude-code)