### PR TITLE
fix(provider): detect auth errors and add timeout to OpenAI provider

### DIFF
--- a/internal/provider/openai.go
+++ b/internal/provider/openai.go
@@ -4,13 +4,19 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"time"
 )
 
 // maxResponseSize is the maximum allowed response body size (10 MB).
 const maxResponseSize = 10 << 20
+
+// openAITimeout is the HTTP client timeout for OpenAI-compatible providers.
+const openAITimeout = 60 * time.Second
 
 // OpenAI is an OpenAI-compatible HTTP provider.
 // Works with any API that implements the OpenAI chat completions endpoint
@@ -30,7 +36,7 @@ func NewOpenAI(name, baseURL, model, apiKey string) *OpenAI {
 		baseURL: baseURL,
 		model:   model,
 		apiKey:  apiKey,
-		client:  &http.Client{},
+		client:  &http.Client{Timeout: openAITimeout},
 	}
 }
 
@@ -63,7 +69,7 @@ func (o *OpenAI) Chat(ctx context.Context, messages []Message) (string, error) {
 
 	resp, err := o.client.Do(req)
 	if err != nil {
-		if ctx.Err() == context.DeadlineExceeded {
+		if isTimeoutError(ctx, err) {
 			return "", fmt.Errorf("send request: %w: %w", ErrTimeout, err)
 		}
 		return "", fmt.Errorf("send request: %w", err)
@@ -79,6 +85,9 @@ func (o *OpenAI) Chat(ctx context.Context, messages []Message) (string, error) {
 	}
 
 	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+			return "", fmt.Errorf("API error (status %d): %s: %w", resp.StatusCode, respBody, ErrAuthFailure)
+		}
 		return "", fmt.Errorf("API error (status %d): %s", resp.StatusCode, respBody)
 	}
 
@@ -139,4 +148,14 @@ type openaiResponse struct {
 
 type openaiChoice struct {
 	Message openaiMessage `json:"message"`
+}
+
+// isTimeoutError returns true if the error indicates a timeout, either from
+// the request context or the HTTP client's own timeout.
+func isTimeoutError(ctx context.Context, err error) bool {
+	if ctx.Err() == context.DeadlineExceeded {
+		return true
+	}
+	var netErr net.Error
+	return errors.Is(err, context.DeadlineExceeded) || (errors.As(err, &netErr) && netErr.Timeout())
 }

--- a/internal/provider/openai_test.go
+++ b/internal/provider/openai_test.go
@@ -3,10 +3,12 @@ package provider
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestOpenAIChat(t *testing.T) {
@@ -76,6 +78,69 @@ func TestOpenAIAPIError(t *testing.T) {
 	_, err := p.Chat(context.Background(), []Message{{Role: "user", Content: "hello"}})
 	if err == nil {
 		t.Fatal("expected error for 429 response")
+	}
+	if errors.Is(err, ErrAuthFailure) {
+		t.Error("429 should not be an auth failure")
+	}
+}
+
+func TestOpenAIAuthError(t *testing.T) {
+	codes := []int{http.StatusUnauthorized, http.StatusForbidden}
+	for _, code := range codes {
+		t.Run(http.StatusText(code), func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(code)
+				w.Write([]byte(`{"error":"invalid api key"}`))
+			}))
+			defer srv.Close()
+
+			p := NewOpenAI("test", srv.URL, "model", "key")
+			_, err := p.Chat(context.Background(), []Message{{Role: "user", Content: "hello"}})
+			if err == nil {
+				t.Fatalf("expected error for %d response", code)
+			}
+			if !errors.Is(err, ErrAuthFailure) {
+				t.Errorf("expected ErrAuthFailure for %d, got: %v", code, err)
+			}
+		})
+	}
+}
+
+func TestOpenAIContextTimeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(500 * time.Millisecond)
+	}))
+	defer srv.Close()
+
+	p := NewOpenAI("test", srv.URL, "model", "key")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	_, err := p.Chat(ctx, []Message{{Role: "user", Content: "hello"}})
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !errors.Is(err, ErrTimeout) {
+		t.Errorf("expected ErrTimeout, got: %v", err)
+	}
+}
+
+func TestOpenAIClientTimeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(500 * time.Millisecond)
+	}))
+	defer srv.Close()
+
+	p := NewOpenAI("test", srv.URL, "model", "key")
+	p.client.Timeout = 100 * time.Millisecond
+
+	_, err := p.Chat(context.Background(), []Message{{Role: "user", Content: "hello"}})
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !errors.Is(err, ErrTimeout) {
+		t.Errorf("expected ErrTimeout, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Wrap HTTP 401/403 responses with `ErrAuthFailure` so the fallback chain and health endpoint correctly identify auth issues for OpenAI-compatible providers
- Set 60s `http.Client` timeout (matching Claude CLI's 60s) to prevent indefinite hangs when an endpoint is unresponsive
- Add `isTimeoutError` helper that detects both context deadlines and client-level timeouts

Closes #99
Closes #100

## Test plan

- [x] `TestOpenAIAuthError` — verifies 401 and 403 wrap `ErrAuthFailure`
- [x] `TestOpenAIAPIError` — verifies 429 does NOT wrap `ErrAuthFailure`
- [x] `TestOpenAIContextTimeout` — verifies context deadline triggers `ErrTimeout`
- [x] `TestOpenAIClientTimeout` — verifies client timeout triggers `ErrTimeout`
- [x] All existing tests pass (`go test ./...`)
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)