### PR TITLE
docs: add README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ Lightweight, self-hosted AI assistant bot for Telegram.
 
 ## Features
 
-- **Provider fallback** -- Claude CLI as primary, any OpenAI-compatible API as backup
-- **Conversation history** -- per-chat message history stored in bbolt (embedded, pure Go)
-- **Long-term memory** -- remembers facts and preferences across conversations
-- **User whitelist** -- only responds to authorized Telegram user IDs
-- **CLI mode** -- test locally with `./herald ask "question"` without Telegram
-- **Telegram commands** -- `/clear` resets context, `/model` switches providers, `/status` shows bot info
-- **Image support** -- understands photos sent in Telegram chats
-- **Single binary** -- no CGO, no Docker, no external dependencies at runtime
+- **Provider fallback** — Claude CLI as primary, any OpenAI-compatible API as backup
+- **Conversation history** — per-chat message history stored in bbolt (embedded, pure Go)
+- **Long-term memory** — remembers facts and preferences across conversations
+- **User whitelist** — only responds to authorized Telegram user IDs
+- **CLI mode** — test locally with `./herald ask "question"` without Telegram
+- **Telegram commands** — `/clear` resets context, `/model` switches providers, `/status` shows bot info
+- **Image support** — understands photos sent in Telegram chats
+- **Single binary** — no CGO, no Docker, no external dependencies at runtime
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary
- Add project README.md (56 lines) with badges, feature list, quick start, and links to existing docs
- Links to docs/ files and AGENTS.md without duplicating content
- Omits License section (no LICENSE file in repo)

Closes #114, closes #80

## Test plan
- [ ] CI badge renders correctly (verify workflow filename matches `ci.yml`)
- [ ] Release badge renders correctly (verify repo path `sgraczyk/herald`)
- [ ] All relative links resolve (docs/*.md, AGENTS.md, .example files)
- [ ] No content overlap with AGENTS.md or docs/

🤖 Generated with [Claude Code](https://claude.com/claude-code)