### PR TITLE
test(telegram): add handleUpdate unit tests

### DIFF
--- a/internal/telegram/adapter_test.go
+++ b/internal/telegram/adapter_test.go
@@ -1,9 +1,12 @@
 package telegram
 
 import (
+	"context"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/go-telegram/bot/models"
 	"github.com/sgraczyk/herald/internal/hub"
 )
 
@@ -132,5 +135,172 @@ func TestAllowedIDsMap(t *testing.T) {
 	}
 	if a.allowedIDs[999] {
 		t.Error("expected user 999 to be rejected")
+	}
+}
+
+func TestParseMessageStatusCommand(t *testing.T) {
+	in := parseMessage(1, 2, "/status")
+	if in.Command != "/status" {
+		t.Errorf("expected command /status, got %q", in.Command)
+	}
+	if in.Text != "/status" {
+		t.Errorf("expected text '/status', got %q", in.Text)
+	}
+}
+
+// testAdapter creates an Adapter with a real Hub, bypassing bot.New.
+func testAdapter(t *testing.T, allowedIDs map[int64]bool) (*Adapter, *hub.Hub) {
+	t.Helper()
+	h := hub.New()
+	return &Adapter{
+		hub:        h,
+		allowedIDs: allowedIDs,
+		typing:     make(map[int64]context.CancelFunc),
+	}, h
+}
+
+// readIn reads from Hub.In with a short timeout to avoid hangs.
+func readIn(t *testing.T, h *hub.Hub) (hub.InMessage, bool) {
+	t.Helper()
+	select {
+	case msg := <-h.In:
+		return msg, true
+	case <-time.After(100 * time.Millisecond):
+		return hub.InMessage{}, false
+	}
+}
+
+func TestHandleUpdateAuthorizedUser(t *testing.T) {
+	a, h := testAdapter(t, map[int64]bool{111: true})
+
+	update := &models.Update{
+		Message: &models.Message{
+			From: &models.User{ID: 111},
+			Chat: models.Chat{ID: 42},
+			Text: "hello",
+		},
+	}
+	a.handleUpdate(context.Background(), nil, update)
+
+	msg, ok := readIn(t, h)
+	if !ok {
+		t.Fatal("expected message on Hub.In, got timeout")
+	}
+	if msg.ChatID != 42 {
+		t.Errorf("expected ChatID 42, got %d", msg.ChatID)
+	}
+	if msg.UserID != 111 {
+		t.Errorf("expected UserID 111, got %d", msg.UserID)
+	}
+	if msg.Text != "hello" {
+		t.Errorf("expected text 'hello', got %q", msg.Text)
+	}
+}
+
+func TestHandleUpdateUnauthorizedUser(t *testing.T) {
+	a, h := testAdapter(t, map[int64]bool{111: true})
+
+	update := &models.Update{
+		Message: &models.Message{
+			From: &models.User{ID: 999},
+			Chat: models.Chat{ID: 42},
+			Text: "hello",
+		},
+	}
+	a.handleUpdate(context.Background(), nil, update)
+
+	_, ok := readIn(t, h)
+	if ok {
+		t.Fatal("expected no message on Hub.In for unauthorized user")
+	}
+}
+
+func TestHandleUpdateEmptyWhitelist(t *testing.T) {
+	a, h := testAdapter(t, map[int64]bool{})
+
+	update := &models.Update{
+		Message: &models.Message{
+			From: &models.User{ID: 111},
+			Chat: models.Chat{ID: 42},
+			Text: "hello",
+		},
+	}
+	a.handleUpdate(context.Background(), nil, update)
+
+	_, ok := readIn(t, h)
+	if ok {
+		t.Fatal("expected no message on Hub.In for empty whitelist")
+	}
+}
+
+func TestHandleUpdateNilMessage(t *testing.T) {
+	a, h := testAdapter(t, map[int64]bool{111: true})
+
+	update := &models.Update{Message: nil}
+	a.handleUpdate(context.Background(), nil, update)
+
+	_, ok := readIn(t, h)
+	if ok {
+		t.Fatal("expected no message on Hub.In for nil message")
+	}
+}
+
+func TestHandleUpdateEmptyText(t *testing.T) {
+	a, h := testAdapter(t, map[int64]bool{111: true})
+
+	update := &models.Update{
+		Message: &models.Message{
+			From: &models.User{ID: 111},
+			Chat: models.Chat{ID: 42},
+			Text: "",
+		},
+	}
+	a.handleUpdate(context.Background(), nil, update)
+
+	_, ok := readIn(t, h)
+	if ok {
+		t.Fatal("expected no message on Hub.In for empty text")
+	}
+}
+
+func TestHandleUpdateWhitespaceText(t *testing.T) {
+	a, h := testAdapter(t, map[int64]bool{111: true})
+
+	update := &models.Update{
+		Message: &models.Message{
+			From: &models.User{ID: 111},
+			Chat: models.Chat{ID: 42},
+			Text: "   ",
+		},
+	}
+	a.handleUpdate(context.Background(), nil, update)
+
+	_, ok := readIn(t, h)
+	if ok {
+		t.Fatal("expected no message on Hub.In for whitespace-only text")
+	}
+}
+
+func TestHandleUpdateCommandParsing(t *testing.T) {
+	a, h := testAdapter(t, map[int64]bool{111: true})
+
+	update := &models.Update{
+		Message: &models.Message{
+			From: &models.User{ID: 111},
+			Chat: models.Chat{ID: 42},
+			Text: "/model chutes",
+		},
+	}
+	a.handleUpdate(context.Background(), nil, update)
+
+	msg, ok := readIn(t, h)
+	if !ok {
+		t.Fatal("expected message on Hub.In, got timeout")
+	}
+	if msg.Command != "/model" {
+		t.Errorf("expected command /model, got %q", msg.Command)
+	}
+	if msg.Text != "chutes" {
+		t.Errorf("expected text 'chutes', got %q", msg.Text)
 	}
 }


### PR DESCRIPTION
## Summary
- Add 8 new tests for `handleUpdate` in `internal/telegram/adapter_test.go` (whitelist enforcement, message filtering, command parsing integration)
- Add `testAdapter` and `readIn` test helpers using real `hub.Hub` with buffered channels
- No production code changes; standard `testing` package only

Closes #75

## Test plan
- [x] `go test ./internal/telegram/...` — 20 tests pass
- [x] `go vet ./internal/telegram/...` — clean
- [x] `go test ./...` — all packages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)