### PR TITLE
fix(ci): use dedicated PAT for release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
   build:
     needs: release-please


### PR DESCRIPTION
## Summary
- Replace `GITHUB_TOKEN` with `RELEASE_PLEASE_TOKEN` in release-please workflow
- Fixes CI not triggering on release-please PRs (e.g. #133) due to GitHub's recursive workflow prevention

## Test plan
- [ ] Verify next release-please PR triggers CI checks automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)