### PR TITLE
feat(format): improve Telegram HTML output for common LLM patterns

### DIFF
--- a/internal/format/split.go
+++ b/internal/format/split.go
@@ -117,11 +117,6 @@ func bestBoundary(html string, limit int) int {
 				if preDep < 0 {
 					preDep = 0
 				}
-			} else if i+4 < len(s) && s[i+1:i+4] == "pre" {
-				// <pre ...> with attributes (e.g. <pre><code class="...">)
-				if next := s[i+4]; next == ' ' || next == '>' {
-					preDep++
-				}
 			}
 			continue
 		}

--- a/internal/format/split.go
+++ b/internal/format/split.go
@@ -79,8 +79,10 @@ func Split(html string, maxLen int) []string {
 }
 
 // bestBoundary finds the best split position at or before limit.
-// Prefers: paragraph break (\n\n) > newline > space > hard cut.
-// Delimiters inside HTML tags are ignored.
+// Prefers boundaries outside <pre> blocks over those inside.
+// Priority: outside-pre \n\n > outside-pre \n > inside-pre \n >
+// outside-pre space > inside-pre space > hard cut.
+// Delimiters inside HTML tags (between < and >) are always ignored.
 func bestBoundary(html string, limit int) int {
 	if limit <= 0 {
 		return 0
@@ -91,38 +93,99 @@ func bestBoundary(html string, limit int) int {
 
 	s := html[:limit]
 
-	if i := lastSafeIndex(s, "\n\n"); i > 0 {
-		return i + 2
+	// Single pass: track HTML tag boundaries and <pre> depth.
+	var (
+		inTag   bool
+		preDep  int
+		outsideParaBreak = -1 // priority 1
+		outsideNewline   = -1 // priority 2
+		insideNewline    = -1 // priority 3
+		outsideSpace     = -1 // priority 4
+		insideSpace      = -1 // priority 5
+	)
+
+	for i := 0; i < len(s); i++ {
+		ch := s[i]
+
+		if ch == '<' {
+			inTag = true
+			// Detect <pre> and </pre> for depth tracking.
+			if i+4 < len(s) && s[i+1:i+5] == "pre>" {
+				preDep++
+			} else if i+5 < len(s) && s[i+1:i+6] == "/pre>" {
+				preDep--
+				if preDep < 0 {
+					preDep = 0
+				}
+			} else if i+4 < len(s) && s[i+1:i+4] == "pre" {
+				// <pre ...> with attributes (e.g. <pre><code class="...">)
+				if next := s[i+4]; next == ' ' || next == '>' {
+					preDep++
+				}
+			}
+			continue
+		}
+		if ch == '>' {
+			inTag = false
+			continue
+		}
+
+		if inTag {
+			continue
+		}
+
+		inPre := preDep > 0
+
+		if ch == '\n' && i+1 < len(s) && s[i+1] == '\n' {
+			if !inPre {
+				outsideParaBreak = i
+			}
+			// \n\n inside pre counts as insideNewline (priority 3)
+			if inPre {
+				insideNewline = i
+			}
+			continue
+		}
+
+		if ch == '\n' {
+			if inPre {
+				insideNewline = i
+			} else {
+				outsideNewline = i
+			}
+			continue
+		}
+
+		if ch == ' ' {
+			if inPre {
+				insideSpace = i
+			} else {
+				outsideSpace = i
+			}
+		}
 	}
-	if i := lastSafeIndex(s, "\n"); i > 0 {
-		return i + 1
+
+	// Return best match by priority.
+	if outsideParaBreak > 0 {
+		return outsideParaBreak + 2
 	}
-	if i := lastSafeIndex(s, " "); i > 0 {
-		return i + 1
+	if outsideNewline > 0 {
+		return outsideNewline + 1
+	}
+	if insideNewline > 0 {
+		return insideNewline + 1
+	}
+	if outsideSpace > 0 {
+		return outsideSpace + 1
+	}
+	if insideSpace > 0 {
+		return insideSpace + 1
 	}
 
 	// Hard cut: avoid landing inside a tag or entity.
 	limit = avoidTagSplit(html, limit)
 	limit = avoidEntitySplit(html, limit)
 	return limit
-}
-
-// lastSafeIndex returns the last index of delim in s that is not inside an HTML tag.
-// Returns -1 if not found.
-func lastSafeIndex(s, delim string) int {
-	inTag := false
-	last := -1
-	dlen := len(delim)
-	for i := 0; i < len(s); i++ {
-		if s[i] == '<' {
-			inTag = true
-		} else if s[i] == '>' {
-			inTag = false
-		} else if !inTag && i+dlen <= len(s) && s[i:i+dlen] == delim {
-			last = i
-		}
-	}
-	return last
 }
 
 // avoidTagSplit adjusts limit to avoid splitting inside an HTML tag.

--- a/internal/format/split_test.go
+++ b/internal/format/split_test.go
@@ -218,3 +218,57 @@ func TestSplit_MultipleChunks(t *testing.T) {
 		}
 	}
 }
+
+func TestSplit_InsidePreUsesNewline(t *testing.T) {
+	// Code block that must be split — should split at a \n inside the block.
+	line := strings.Repeat("x", 40) + "\n"
+	code := "<pre>" + strings.Repeat(line, 5) + "</pre>"
+	got := Split(code, 120)
+	if len(got) < 2 {
+		t.Fatalf("expected multiple chunks, got %d", len(got))
+	}
+	// Each chunk should end at a line boundary (before closing tags)
+	for i, chunk := range got {
+		if len(chunk) > 120 {
+			t.Errorf("chunk %d exceeds maxLen: len=%d", i, len(chunk))
+		}
+	}
+}
+
+func TestSplit_MixedContentBlockBoundary(t *testing.T) {
+	// paragraph + code block — should split at the \n\n between them
+	para := strings.Repeat("word ", 8) // 40 chars
+	code := "<pre><code>" + strings.Repeat("c", 30) + "</code></pre>"
+	s := para + "\n\n" + code
+	got := Split(s, 55)
+	if len(got) < 2 {
+		t.Fatalf("expected multiple chunks, got %d", len(got))
+	}
+	// First chunk should be the paragraph text ending at \n\n
+	if !strings.HasSuffix(got[0], "\n\n") {
+		t.Errorf("first chunk should end at paragraph break, got: %q", got[0])
+	}
+	// Second chunk should start with the code block
+	if !strings.HasPrefix(got[1], "<pre>") {
+		t.Errorf("second chunk should start with <pre>, got: %q", got[1])
+	}
+}
+
+func TestSplit_LargePreBlockNewlineBoundary(t *testing.T) {
+	// Single code block that exceeds maxLen — must split inside at \n boundaries
+	line := "func example() { return nil }\n" // 30 chars per line
+	code := "<pre><code>" + strings.Repeat(line, 10) + "</code></pre>"
+	got := Split(code, 120)
+	if len(got) < 2 {
+		t.Fatalf("expected multiple chunks, got %d", len(got))
+	}
+	for i, chunk := range got {
+		if len(chunk) > 120 {
+			t.Errorf("chunk %d exceeds maxLen: len=%d", i, len(chunk))
+		}
+		// All chunks should have pre+code tags (repaired)
+		if !strings.Contains(chunk, "<pre>") {
+			t.Errorf("chunk %d missing <pre> tag", i)
+		}
+	}
+}

--- a/internal/format/split_test.go
+++ b/internal/format/split_test.go
@@ -185,6 +185,27 @@ func TestSplit_DefaultMaxLen(t *testing.T) {
 	}
 }
 
+func TestSplit_PrefersOutsidePreBoundary(t *testing.T) {
+	// Outside \n\n appears early, then a <pre> block contains \n\n later.
+	// The old bestBoundary picks the last \n\n (inside <pre>).
+	// The new one should prefer the outside \n\n.
+	text := strings.Repeat("a", 20)
+	code := "<pre>" + strings.Repeat("x", 10) + "\n\n" + strings.Repeat("y", 10) + "</pre>"
+	s := text + "\n\n" + code
+	// total len = 20 + 2 + 5 + 10 + 2 + 10 + 6 = 55
+	got := Split(s, 50)
+	if len(got) < 2 {
+		t.Fatalf("expected multiple chunks, got %d", len(got))
+	}
+	// First chunk should end at the paragraph break outside <pre>
+	if !strings.HasSuffix(got[0], "\n\n") {
+		t.Errorf("first chunk should end at paragraph break, got: %q", got[0])
+	}
+	if strings.Contains(got[0], "<pre>") {
+		t.Errorf("first chunk should not contain <pre>, got: %q", got[0])
+	}
+}
+
 func TestSplit_MultipleChunks(t *testing.T) {
 	s := strings.Repeat("a", 500)
 	got := Split(s, 100)

--- a/internal/format/telegram.go
+++ b/internal/format/telegram.go
@@ -134,8 +134,35 @@ func (r *telegramRenderer) renderList(_ util.BufWriter, _ []byte, _ ast.Node, _ 
 	return ast.WalkContinue, nil
 }
 
+// listDepth returns the nesting depth of a list item by counting ancestor
+// List nodes. Returns 0 for top-level, capped at 2 (three levels).
+func listDepth(node ast.Node) int {
+	depth := 0
+	for p := node.Parent(); p != nil; p = p.Parent() {
+		if p.Kind() == ast.KindList {
+			depth++
+		}
+	}
+	// depth counts the List ancestors; the item's own parent List = 1,
+	// so subtract 1 to get nesting level (0-based).
+	depth--
+	if depth < 0 {
+		depth = 0
+	}
+	if depth > 2 {
+		depth = 2
+	}
+	return depth
+}
+
+// bullets maps nesting depth to bullet character for unordered lists.
+var bullets = [3]string{"• ", "◦ ", "▪ "}
+
 func (r *telegramRenderer) renderListItem(w util.BufWriter, _ []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
 	if entering {
+		depth := listDepth(node)
+		indent := strings.Repeat("\u00a0\u00a0", depth)
+
 		list := node.Parent().(*ast.List)
 		if list.IsOrdered() {
 			index := 1
@@ -145,9 +172,9 @@ func (r *telegramRenderer) renderListItem(w util.BufWriter, _ []byte, node ast.N
 			for c := node.Parent().FirstChild(); c != nil && c != node; c = c.NextSibling() {
 				index++
 			}
-			_, _ = fmt.Fprintf(w, "%d. ", index)
+			_, _ = fmt.Fprintf(w, "%s%d. ", indent, index)
 		} else {
-			_, _ = w.WriteString("• ")
+			_, _ = w.WriteString(indent + bullets[depth])
 		}
 	}
 	return ast.WalkContinue, nil

--- a/internal/format/telegram.go
+++ b/internal/format/telegram.go
@@ -81,9 +81,14 @@ func (r *telegramRenderer) renderDocument(_ util.BufWriter, _ []byte, _ ast.Node
 	return ast.WalkContinue, nil
 }
 
-func (r *telegramRenderer) renderParagraph(w util.BufWriter, _ []byte, _ ast.Node, entering bool) (ast.WalkStatus, error) {
+func (r *telegramRenderer) renderParagraph(w util.BufWriter, _ []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
 	if !entering {
-		_, _ = w.WriteString("\n\n")
+		// Inside nested list items, use single newline to avoid awkward double-spacing.
+		if node.Parent() != nil && node.Parent().Kind() == ast.KindListItem && listDepth(node.Parent()) > 0 {
+			_, _ = w.WriteString("\n")
+		} else {
+			_, _ = w.WriteString("\n\n")
+		}
 	}
 	return ast.WalkContinue, nil
 }

--- a/internal/format/telegram_test.go
+++ b/internal/format/telegram_test.go
@@ -252,6 +252,19 @@ func TestTelegramHTML_TopLevelLooseList(t *testing.T) {
 	}
 }
 
+func TestTelegramHTML_LooseNestedList(t *testing.T) {
+	// Loose list: blank line between items makes goldmark wrap content in Paragraph nodes
+	input := "- top\n\n  - nested\n\n  - also nested"
+	got := TelegramHTML(input)
+	// Nested items should NOT get double-spaced \n\n between them
+	if strings.Contains(got, "nested\n\n") {
+		t.Errorf("nested items should not be double-spaced, got:\n%s", got)
+	}
+	if !strings.Contains(got, "◦ nested") {
+		t.Errorf("expected nested bullet, got:\n%s", got)
+	}
+}
+
 func BenchmarkTelegramHTML(b *testing.B) {
 	input := `# Weather Report
 

--- a/internal/format/telegram_test.go
+++ b/internal/format/telegram_test.go
@@ -201,6 +201,57 @@ func TestTelegramHTML_NestedUnorderedList(t *testing.T) {
 	}
 }
 
+func TestTelegramHTML_DeeplyNestedUnorderedList(t *testing.T) {
+	input := "- top\n  - mid\n    - deep"
+	got := TelegramHTML(input)
+	want := "• top\n\u00a0\u00a0◦ mid\n\u00a0\u00a0\u00a0\u00a0▪ deep"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestTelegramHTML_NestedOrderedList(t *testing.T) {
+	input := "1. top\n   1. nested\n   2. also nested"
+	got := TelegramHTML(input)
+	want := "1. top\n\u00a0\u00a01. nested\n\u00a0\u00a02. also nested"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestTelegramHTML_MixedNestedList(t *testing.T) {
+	input := "1. top\n   - nested bullet"
+	got := TelegramHTML(input)
+	want := "1. top\n\u00a0\u00a0◦ nested bullet"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestTelegramHTML_NestedListDepthCap(t *testing.T) {
+	input := "- a\n  - b\n    - c\n      - d"
+	got := TelegramHTML(input)
+	// 4th level should render same as 3rd level (depth capped at 2)
+	if !strings.Contains(got, "\u00a0\u00a0\u00a0\u00a0▪ c") {
+		t.Errorf("expected depth-2 bullet for 'c', got:\n%s", got)
+	}
+	if !strings.Contains(got, "\u00a0\u00a0\u00a0\u00a0▪ d") {
+		t.Errorf("expected depth-2 bullet for 'd' (capped), got:\n%s", got)
+	}
+}
+
+func TestTelegramHTML_TopLevelLooseList(t *testing.T) {
+	// Top-level loose list should still get \n\n paragraph spacing
+	input := "- item one\n\n- item two"
+	got := TelegramHTML(input)
+	if !strings.Contains(got, "• item one") {
+		t.Errorf("expected bullet for item one, got:\n%s", got)
+	}
+	if !strings.Contains(got, "• item two") {
+		t.Errorf("expected bullet for item two, got:\n%s", got)
+	}
+}
+
 func BenchmarkTelegramHTML(b *testing.B) {
 	input := `# Weather Report
 

--- a/internal/format/telegram_test.go
+++ b/internal/format/telegram_test.go
@@ -192,6 +192,15 @@ func TestTelegramHTML_MixedContent(t *testing.T) {
 	}
 }
 
+func TestTelegramHTML_NestedUnorderedList(t *testing.T) {
+	input := "- top\n  - nested"
+	got := TelegramHTML(input)
+	want := "• top\n\u00a0\u00a0◦ nested"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func BenchmarkTelegramHTML(b *testing.B) {
 	input := `# Weather Report
 


### PR DESCRIPTION
## Summary

Closes #147

- **Nested list indentation:** `listDepth` helper walks the goldmark AST to determine nesting depth (capped at 3 levels). `renderListItem` prepends non-breaking spaces and uses depth-specific bullets (`•`/`◦`/`▪`). `renderParagraph` emits `\n` instead of `\n\n` inside nested list items to prevent double-spacing in loose lists.
- **Code-block-aware splitting:** `bestBoundary` rewritten with a single-pass scanner that tracks `<pre>` block depth. Prefers splitting outside code blocks (6-level priority: outside-pre `\n\n` > outside-pre `\n` > inside-pre `\n` > outside-pre space > inside-pre space > hard cut). `lastSafeIndex` removed. Tag repair remains as fallback for oversized code blocks.
- Code blocks already render with `<pre><code class="language-X">` — no changes needed.

## Test Plan

- [x] 7 new nested list tests (2-level, 3-level, ordered, mixed, depth cap, loose, top-level loose regression)
- [x] 4 new split tests (prefer outside-pre, inside-pre newline, mixed content boundary, large pre block)
- [x] All 48 format tests pass
- [x] Full test suite passes (`go test ./...`)
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)