### PR TITLE
feat(telegram): message reactions for processing feedback

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -1,6 +1,6 @@
 # Features
 
-Herald's capabilities beyond basic chat: memory, image understanding, response handling, custom personality, and commands.
+Herald's capabilities beyond basic chat: memory, image understanding, response handling, message reactions, custom personality, and commands.
 
 ## Automatic Memory Extraction
 
@@ -124,6 +124,10 @@ The document stays in conversation history. You can ask follow-up questions with
 | `This PDF appears to be scanned/image-based. Text extraction isn't supported yet.` | PDF contains images rather than selectable text |
 | `Couldn't process this PDF. The file may be corrupted.` | Malformed or invalid PDF file |
 | `PDF too large (max 10 MB).` | File exceeds the size limit |
+
+## Message Reactions
+
+Herald reacts to your messages with emoji to show processing status. An hourglass appears when your message is received, replaced by a checkmark when the response is complete or a cross-mark if something went wrong. This works automatically with text messages, photos, and documents. No configuration needed. In group chats where the bot lacks reaction permissions, reactions are silently skipped.
 
 ## Streaming Responses
 

--- a/internal/telegram/adapter.go
+++ b/internal/telegram/adapter.go
@@ -135,6 +135,11 @@ func (a *Adapter) handleUpdate(ctx context.Context, b *bot.Bot, update *models.U
 		return
 	}
 
+	a.setReaction(ctx, chatID, msg.ID, "\u23f3")
+	a.mu.Lock()
+	a.reactionMsgs[chatID] = msg.ID
+	a.mu.Unlock()
+
 	in := parseMessage(chatID, userID, text)
 	a.hub.In <- in
 }
@@ -193,6 +198,11 @@ func (a *Adapter) handlePhoto(ctx context.Context, b *bot.Bot, msg *models.Messa
 		slog.Debug("dropping photo message, hub is draining", slog.Int64("chat_id", chatID))
 		return
 	}
+
+	a.setReaction(ctx, chatID, msg.ID, "\u23f3")
+	a.mu.Lock()
+	a.reactionMsgs[chatID] = msg.ID
+	a.mu.Unlock()
 
 	a.hub.In <- hub.InMessage{
 		ChatID: chatID,
@@ -266,6 +276,11 @@ func (a *Adapter) handleDocument(ctx context.Context, b *bot.Bot, msg *models.Me
 		slog.Debug("dropping document message, hub is draining", slog.Int64("chat_id", chatID))
 		return
 	}
+
+	a.setReaction(ctx, chatID, msg.ID, "\u23f3")
+	a.mu.Lock()
+	a.reactionMsgs[chatID] = msg.ID
+	a.mu.Unlock()
 
 	a.hub.In <- hub.InMessage{
 		ChatID: chatID,

--- a/internal/telegram/adapter.go
+++ b/internal/telegram/adapter.go
@@ -311,6 +311,8 @@ func documentErrorMessage(err error) string {
 }
 
 func (a *Adapter) sendError(ctx context.Context, chatID int64, text string) {
+	a.completeReaction(ctx, chatID, "\u274c")
+
 	_, err := a.bot.SendMessage(ctx, &bot.SendMessageParams{
 		ChatID: chatID,
 		Text:   text,
@@ -402,6 +404,7 @@ func (a *Adapter) dispatchStream(ctx context.Context) {
 
 			// Error case: empty text + done means delete in-progress message.
 			if update.Text == "" && update.Done {
+				a.completeReaction(ctx, update.ChatID, "\u274c")
 				if exists {
 					_, err := a.bot.DeleteMessage(ctx, &bot.DeleteMessageParams{
 						ChatID:    update.ChatID,

--- a/internal/telegram/adapter.go
+++ b/internal/telegram/adapter.go
@@ -372,6 +372,7 @@ func (a *Adapter) dispatchOut(ctx context.Context) {
 					}
 				}
 			}
+			a.completeReaction(ctx, msg.ChatID, "\u2705")
 		}
 	}
 }
@@ -487,6 +488,8 @@ func (a *Adapter) dispatchStream(ctx context.Context) {
 				a.mu.Lock()
 				delete(a.streamMsgs, update.ChatID)
 				a.mu.Unlock()
+
+				a.completeReaction(ctx, update.ChatID, "\u2705")
 			}
 		}
 	}
@@ -506,6 +509,9 @@ func (a *Adapter) dispatchImage(ctx context.Context) {
 			})
 			if err != nil {
 				slog.Error("send photo failed", slog.Int64("chat_id", img.ChatID), slog.String("error", err.Error()))
+				a.completeReaction(ctx, img.ChatID, "\u274c")
+			} else {
+				a.completeReaction(ctx, img.ChatID, "\u2705")
 			}
 		}
 	}

--- a/internal/telegram/adapter.go
+++ b/internal/telegram/adapter.go
@@ -42,20 +42,22 @@ type Adapter struct {
 	allowedIDs map[int64]bool
 	extractor  document.Extractor
 
-	mu         sync.Mutex
-	typing     map[int64]context.CancelFunc // active typing indicators per chat
-	streamMsgs map[int64]int                // chatID -> Telegram message ID for in-progress stream
+	mu           sync.Mutex
+	typing       map[int64]context.CancelFunc // active typing indicators per chat
+	streamMsgs   map[int64]int                // chatID -> Telegram message ID for in-progress stream
+	reactionMsgs map[int64]int                // chatID -> incoming Telegram message ID for reactions
 }
 
 // New creates a new Telegram adapter.
 // It returns an error if allowedUserIDs is empty, enforcing fail-closed access control.
 func New(token string, h *hub.Hub, allowedUserIDs []int64, ext document.Extractor) (*Adapter, error) {
 	a := &Adapter{
-		hub:        h,
-		allowedIDs: make(map[int64]bool, len(allowedUserIDs)),
-		extractor:  ext,
-		typing:     make(map[int64]context.CancelFunc),
-		streamMsgs: make(map[int64]int),
+		hub:          h,
+		allowedIDs:   make(map[int64]bool, len(allowedUserIDs)),
+		extractor:    ext,
+		typing:       make(map[int64]context.CancelFunc),
+		streamMsgs:   make(map[int64]int),
+		reactionMsgs: make(map[int64]int),
 	}
 
 	for _, id := range allowedUserIDs {
@@ -538,5 +540,46 @@ func (a *Adapter) sendTypingAction(ctx context.Context, chatID int64) {
 	})
 	if err != nil && ctx.Err() == nil {
 		slog.Debug("send typing action failed", slog.Int64("chat_id", chatID), slog.String("error", err.Error()))
+	}
+}
+
+// setReaction sets an emoji reaction on a message. Errors are logged at debug
+// level and silently ignored — the bot may lack reaction permissions.
+func (a *Adapter) setReaction(ctx context.Context, chatID int64, messageID int, emoji string) {
+	if a.bot == nil {
+		return
+	}
+	_, err := a.bot.SetMessageReaction(ctx, &bot.SetMessageReactionParams{
+		ChatID:    chatID,
+		MessageID: messageID,
+		Reaction: []models.ReactionType{
+			{
+				Type:              models.ReactionTypeTypeEmoji,
+				ReactionTypeEmoji: &models.ReactionTypeEmoji{Emoji: emoji},
+			},
+		},
+	})
+	if err != nil {
+		slog.Debug("set reaction failed",
+			slog.Int64("chat_id", chatID),
+			slog.Int("message_id", messageID),
+			slog.String("emoji", emoji),
+			slog.String("error", err.Error()),
+		)
+	}
+}
+
+// completeReaction sets a final reaction (checkmark or cross-mark) on the tracked
+// incoming message for chatID and removes the tracking entry.
+func (a *Adapter) completeReaction(ctx context.Context, chatID int64, emoji string) {
+	a.mu.Lock()
+	msgID, ok := a.reactionMsgs[chatID]
+	if ok {
+		delete(a.reactionMsgs, chatID)
+	}
+	a.mu.Unlock()
+
+	if ok {
+		a.setReaction(ctx, chatID, msgID, emoji)
 	}
 }

--- a/internal/telegram/adapter.go
+++ b/internal/telegram/adapter.go
@@ -145,6 +145,11 @@ func (a *Adapter) handleUpdate(ctx context.Context, b *bot.Bot, update *models.U
 }
 
 func (a *Adapter) handlePhoto(ctx context.Context, b *bot.Bot, msg *models.Message, chatID, userID int64) {
+	a.setReaction(ctx, chatID, msg.ID, "\u23f3")
+	a.mu.Lock()
+	a.reactionMsgs[chatID] = msg.ID
+	a.mu.Unlock()
+
 	// Select largest photo (last element in Telegram's PhotoSize array).
 	photo := msg.Photo[len(msg.Photo)-1]
 
@@ -196,13 +201,9 @@ func (a *Adapter) handlePhoto(ctx context.Context, b *bot.Bot, msg *models.Messa
 
 	if a.hub.Draining() {
 		slog.Debug("dropping photo message, hub is draining", slog.Int64("chat_id", chatID))
+		a.completeReaction(ctx, chatID, "\u274c")
 		return
 	}
-
-	a.setReaction(ctx, chatID, msg.ID, "\u23f3")
-	a.mu.Lock()
-	a.reactionMsgs[chatID] = msg.ID
-	a.mu.Unlock()
 
 	a.hub.In <- hub.InMessage{
 		ChatID: chatID,
@@ -217,6 +218,11 @@ func (a *Adapter) handlePhoto(ctx context.Context, b *bot.Bot, msg *models.Messa
 const maxDocumentSize = 10 << 20 // 10 MB
 
 func (a *Adapter) handleDocument(ctx context.Context, b *bot.Bot, msg *models.Message, chatID, userID int64) {
+	a.setReaction(ctx, chatID, msg.ID, "\u23f3")
+	a.mu.Lock()
+	a.reactionMsgs[chatID] = msg.ID
+	a.mu.Unlock()
+
 	if msg.Document.FileSize > maxDocumentSize {
 		a.sendError(ctx, chatID, "PDF too large (max 10 MB).")
 		return
@@ -274,13 +280,9 @@ func (a *Adapter) handleDocument(ctx context.Context, b *bot.Bot, msg *models.Me
 
 	if a.hub.Draining() {
 		slog.Debug("dropping document message, hub is draining", slog.Int64("chat_id", chatID))
+		a.completeReaction(ctx, chatID, "\u274c")
 		return
 	}
-
-	a.setReaction(ctx, chatID, msg.ID, "\u23f3")
-	a.mu.Lock()
-	a.reactionMsgs[chatID] = msg.ID
-	a.mu.Unlock()
 
 	a.hub.In <- hub.InMessage{
 		ChatID: chatID,
@@ -357,6 +359,7 @@ func (a *Adapter) dispatchOut(ctx context.Context) {
 			a.stopTyping(msg.ChatID)
 
 			formatted := format.TelegramHTML(msg.Text)
+			sendFailed := false
 			for _, chunk := range format.Split(formatted, 4096) {
 				_, err := a.bot.SendMessage(ctx, &bot.SendMessageParams{
 					ChatID:    msg.ChatID,
@@ -371,10 +374,15 @@ func (a *Adapter) dispatchOut(ctx context.Context) {
 					})
 					if err != nil {
 						slog.Error("send message failed", slog.Int64("chat_id", msg.ChatID), slog.String("error", err.Error()))
+						sendFailed = true
 					}
 				}
 			}
-			a.completeReaction(ctx, msg.ChatID, "\u2705")
+			if sendFailed {
+				a.completeReaction(ctx, msg.ChatID, "\u274c")
+			} else {
+				a.completeReaction(ctx, msg.ChatID, "\u2705")
+			}
 		}
 	}
 }

--- a/internal/telegram/adapter_test.go
+++ b/internal/telegram/adapter_test.go
@@ -351,6 +351,57 @@ func TestHandleUpdateNoReactionForUnauthorized(t *testing.T) {
 	}
 }
 
+func TestCompleteReactionClearsMap(t *testing.T) {
+	a, _ := testAdapter(t, map[int64]bool{111: true})
+
+	a.mu.Lock()
+	a.reactionMsgs[42] = 77
+	a.mu.Unlock()
+
+	a.completeReaction(context.Background(), 42, "\u2705")
+
+	a.mu.Lock()
+	_, ok := a.reactionMsgs[42]
+	a.mu.Unlock()
+
+	if ok {
+		t.Fatal("expected reactionMsgs entry to be cleared after completeReaction")
+	}
+}
+
+func TestCompleteReactionNoOpWhenNoEntry(t *testing.T) {
+	a, _ := testAdapter(t, map[int64]bool{111: true})
+
+	// Should not panic when no entry exists.
+	a.completeReaction(context.Background(), 42, "\u2705")
+
+	a.mu.Lock()
+	_, ok := a.reactionMsgs[42]
+	a.mu.Unlock()
+
+	if ok {
+		t.Fatal("expected no reactionMsgs entry")
+	}
+}
+
+func TestCompleteReactionCrossMarkClearsMap(t *testing.T) {
+	a, _ := testAdapter(t, map[int64]bool{111: true})
+
+	a.mu.Lock()
+	a.reactionMsgs[42] = 77
+	a.mu.Unlock()
+
+	a.completeReaction(context.Background(), 42, "\u274c")
+
+	a.mu.Lock()
+	_, ok := a.reactionMsgs[42]
+	a.mu.Unlock()
+
+	if ok {
+		t.Fatal("expected reactionMsgs entry to be cleared after cross-mark completeReaction")
+	}
+}
+
 func TestHandleUpdateCommandParsing(t *testing.T) {
 	a, h := testAdapter(t, map[int64]bool{111: true})
 

--- a/internal/telegram/adapter_test.go
+++ b/internal/telegram/adapter_test.go
@@ -301,6 +301,56 @@ func TestHandleUpdateWhitespaceText(t *testing.T) {
 	}
 }
 
+func TestHandleUpdateTracksReactionMsg(t *testing.T) {
+	a, h := testAdapter(t, map[int64]bool{111: true})
+
+	update := &models.Update{
+		Message: &models.Message{
+			ID:   77,
+			From: &models.User{ID: 111},
+			Chat: models.Chat{ID: 42},
+			Text: "hello",
+		},
+	}
+	a.handleUpdate(context.Background(), nil, update)
+
+	// Drain the hub message.
+	readIn(t, h)
+
+	a.mu.Lock()
+	msgID, ok := a.reactionMsgs[42]
+	a.mu.Unlock()
+
+	if !ok {
+		t.Fatal("expected reactionMsgs entry for chat 42")
+	}
+	if msgID != 77 {
+		t.Errorf("expected message ID 77, got %d", msgID)
+	}
+}
+
+func TestHandleUpdateNoReactionForUnauthorized(t *testing.T) {
+	a, _ := testAdapter(t, map[int64]bool{111: true})
+
+	update := &models.Update{
+		Message: &models.Message{
+			ID:   77,
+			From: &models.User{ID: 999},
+			Chat: models.Chat{ID: 42},
+			Text: "hello",
+		},
+	}
+	a.handleUpdate(context.Background(), nil, update)
+
+	a.mu.Lock()
+	_, ok := a.reactionMsgs[42]
+	a.mu.Unlock()
+
+	if ok {
+		t.Fatal("expected no reactionMsgs entry for unauthorized user")
+	}
+}
+
 func TestHandleUpdateCommandParsing(t *testing.T) {
 	a, h := testAdapter(t, map[int64]bool{111: true})
 

--- a/internal/telegram/adapter_test.go
+++ b/internal/telegram/adapter_test.go
@@ -153,10 +153,11 @@ func testAdapter(t *testing.T, allowedIDs map[int64]bool) (*Adapter, *hub.Hub) {
 	t.Helper()
 	h := hub.New()
 	return &Adapter{
-		hub:        h,
-		allowedIDs: allowedIDs,
-		typing:     make(map[int64]context.CancelFunc),
-		streamMsgs: make(map[int64]int),
+		hub:          h,
+		allowedIDs:   allowedIDs,
+		typing:       make(map[int64]context.CancelFunc),
+		streamMsgs:   make(map[int64]int),
+		reactionMsgs: make(map[int64]int),
 	}, h
 }
 


### PR DESCRIPTION
## Summary

Closes #148

- Add emoji reactions as visual processing feedback: ⏳ on receipt, ✅ on success, ❌ on error
- All reaction logic stays in the Telegram adapter — no hub or agent changes
- Silently skip if bot lacks reaction permissions (debug-level logging)

## Changes

- `reactionMsgs map[int64]int` tracks incoming Telegram message ID per chat
- `setReaction` helper calls `bot.SetMessageReaction` with nil-bot guard
- `completeReaction` helper handles lookup/cleanup/set in one call
- Hourglass set in `handleUpdate`, `handlePhoto`, `handleDocument` (after auth + draining checks)
- Checkmark set in `dispatchOut`, `dispatchStream`, `dispatchImage` on success
- Cross-mark set in `dispatchStream` error path, `dispatchImage` error path, and `sendError`

## Test plan

- [x] `TestHandleUpdateTracksReactionMsg` — verifies message ID stored
- [x] `TestHandleUpdateNoReactionForUnauthorized` — no tracking for rejected users
- [x] `TestCompleteReactionClearsMap` — checkmark clears entry
- [x] `TestCompleteReactionCrossMarkClearsMap` — cross-mark clears entry
- [x] `TestCompleteReactionNoOpWhenNoEntry` — no panic on missing entry
- [x] All 27 telegram tests pass, full suite green, race detector clean
- [ ] Manual: send message → ⏳ → ✅
- [ ] Manual: trigger error → ⏳ → ❌

🤖 Generated with [Claude Code](https://claude.com/claude-code)