### PR TITLE
fix(provider): correct Chutes.ai image generation URL and body format

### DIFF
--- a/cmd/herald/main.go
+++ b/cmd/herald/main.go
@@ -122,7 +122,7 @@ func serve(configPath string) error {
 			slog.Warn("image provider skipped: API key not set", slog.String("name", ip.Name))
 			continue
 		}
-		imgProviders = append(imgProviders, provider.NewChutes(ip.Name, ip.BaseURL, ip.APIKey))
+		imgProviders = append(imgProviders, provider.NewChutes(ip.Name, ip.BaseURL, ip.Model, ip.APIKey))
 		slog.Debug("image provider configured", slog.String("name", ip.Name))
 	}
 

--- a/config.json.example
+++ b/config.json.example
@@ -19,13 +19,14 @@
     {
       "name": "z-image",
       "type": "chutes",
-      "base_url": "https://api.chutes.ai/chutes/fe85d993-9a61-5cc1-a21e-64fe4e50d612",
+      "base_url": "https://chutes-z-image-turbo.chutes.ai",
       "api_key_env": "CHUTES_API_KEY"
     },
     {
       "name": "flux",
       "type": "chutes",
-      "base_url": "https://api.chutes.ai/chutes/a292d47b-8f0f-5662-b2b0-6f0ebba48031",
+      "base_url": "https://image.chutes.ai",
+      "model": "FLUX.1-schnell",
       "api_key_env": "CHUTES_API_KEY"
     }
   ],

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -90,7 +90,8 @@ Then run `./herald`. Herald looks for `config.json` in the current directory by 
 | `image_providers` | array | No | `[]` | Image generation providers in fallback order |
 | `image_providers[].name` | string | Yes | -- | Display label (used in logs) |
 | `image_providers[].type` | string | Yes | -- | `"chutes"` (Chutes.ai) or `"none"` (skip entry) |
-| `image_providers[].base_url` | string | If type is chutes | -- | Chute API base URL (e.g. `https://api.chutes.ai/chutes/<id>`) |
+| `image_providers[].base_url` | string | If type is chutes | -- | Chutes.ai base URL — slug-based subdomain (e.g. `https://chutes-z-image-turbo.chutes.ai`) or shared endpoint (`https://image.chutes.ai`) |
+| `image_providers[].model` | string | No | -- | Model identifier (e.g. `"FLUX.1-schnell"`). Required for shared-endpoint providers; omit for slug-based subdomains that serve a single model. |
 | `image_providers[].api_key_env` | string | If type is chutes | -- | Env var name holding the Chutes.ai API key |
 | `allowed_user_ids_env` | string | Yes | -- | Env var name holding comma-separated allowed Telegram user IDs |
 
@@ -157,13 +158,14 @@ Herald can generate images using Chutes.ai. Multiple providers can be configured
   {
     "name": "z-image",
     "type": "chutes",
-    "base_url": "https://api.chutes.ai/chutes/fe85d993-9a61-5cc1-a21e-64fe4e50d612",
+    "base_url": "https://chutes-z-image-turbo.chutes.ai",
     "api_key_env": "CHUTES_API_KEY"
   },
   {
     "name": "flux",
     "type": "chutes",
-    "base_url": "https://api.chutes.ai/chutes/a292d47b-8f0f-5662-b2b0-6f0ebba48031",
+    "base_url": "https://image.chutes.ai",
+    "model": "FLUX.1-schnell",
     "api_key_env": "CHUTES_API_KEY"
   }
 ]

--- a/docs/features.md
+++ b/docs/features.md
@@ -75,7 +75,7 @@ A Chutes.ai API key is required. Add the `image_providers` section to `config.js
     {
       "name": "z-image",
       "type": "chutes",
-      "base_url": "https://api.chutes.ai/chutes/fe85d993-9a61-5cc1-a21e-64fe4e50d612",
+      "base_url": "https://chutes-z-image-turbo.chutes.ai",
       "api_key_env": "CHUTES_API_KEY"
     }
   ]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -51,6 +51,7 @@ type ImageProviderConfig struct {
 	Name      string `json:"name"`
 	Type      string `json:"type"` // "chutes" or "none"
 	BaseURL   string `json:"base_url,omitempty"`
+	Model     string `json:"model,omitempty"`
 	APIKeyEnv string `json:"api_key_env,omitempty"`
 	APIKey    string `json:"-"`
 }

--- a/internal/provider/imagegen.go
+++ b/internal/provider/imagegen.go
@@ -29,21 +29,25 @@ const chutesTimeout = 60 * time.Second
 // separate from maxResponseSize which caps LLM text responses.
 const maxImageResponseSize = 20 << 20
 
-// Chutes generates images using the Chutes.ai API (e.g. FLUX.1-schnell).
+// Chutes generates images using the Chutes.ai API.
 type Chutes struct {
 	name    string
 	baseURL string
+	model   string
 	apiKey  string
 	client  *http.Client
 }
 
-// NewChutes creates a new Chutes.ai image provider. The baseURL is the chute
-// API base (e.g. "https://api.chutes.ai/chutes/<id>"); "/generate" is appended
-// internally.
-func NewChutes(name, baseURL, apiKey string) *Chutes {
+// NewChutes creates a new Chutes.ai image provider. The baseURL depends on the
+// provider type: slug-based subdomains like "https://chutes-z-image-turbo.chutes.ai"
+// or the shared image endpoint "https://image.chutes.ai". "/generate" is
+// appended internally. When model is non-empty (e.g. "FLUX.1-schnell"), it is
+// included in the request body.
+func NewChutes(name, baseURL, model, apiKey string) *Chutes {
 	return &Chutes{
 		name:    name,
 		baseURL: strings.TrimRight(baseURL, "/"),
+		model:   model,
 		apiKey:  apiKey,
 		client:  &http.Client{Timeout: chutesTimeout},
 	}
@@ -55,11 +59,10 @@ func (c *Chutes) Name() string { return c.name }
 // Generate creates an image from a text prompt using the Chutes.ai API.
 func (c *Chutes) Generate(ctx context.Context, prompt string) ([]byte, error) {
 	reqBody := chutesRequest{
-		InputArgs: chutesInputArgs{
-			Prompt: prompt,
-			Width:  1024,
-			Height: 1024,
-		},
+		Model:  c.model,
+		Prompt: prompt,
+		Width:  1024,
+		Height: 1024,
 	}
 
 	body, err := json.Marshal(reqBody)
@@ -163,10 +166,7 @@ func (f *ImageFallback) Generate(ctx context.Context, prompt string) ([]byte, er
 }
 
 type chutesRequest struct {
-	InputArgs chutesInputArgs `json:"input_args"`
-}
-
-type chutesInputArgs struct {
+	Model  string `json:"model,omitempty"`
 	Prompt string `json:"prompt"`
 	Width  int    `json:"width"`
 	Height int    `json:"height"`

--- a/internal/provider/imagegen_test.go
+++ b/internal/provider/imagegen_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestChutes_Generate(t *testing.T) {
-	fakeImage := []byte("fake-jpeg-image-data")
+	fakeImage := []byte("fake-png-image-data")
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
@@ -28,32 +28,42 @@ func TestChutes_Generate(t *testing.T) {
 			t.Errorf("unexpected content-type: %s", r.Header.Get("Content-Type"))
 		}
 
-		var req struct {
-			InputArgs struct {
-				Prompt string `json:"prompt"`
-				Width  int    `json:"width"`
-				Height int    `json:"height"`
-			} `json:"input_args"`
-		}
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		// Decode into a generic map to verify flat body (no input_args wrapper).
+		var raw map[string]json.RawMessage
+		if err := json.NewDecoder(r.Body).Decode(&raw); err != nil {
 			t.Fatalf("decode request: %v", err)
 		}
-		if req.InputArgs.Prompt != "a cute cat" {
-			t.Errorf("expected prompt 'a cute cat', got %s", req.InputArgs.Prompt)
+		if _, ok := raw["input_args"]; ok {
+			t.Error("request body contains input_args wrapper, expected flat body")
 		}
-		if req.InputArgs.Width != 1024 {
-			t.Errorf("expected width 1024, got %d", req.InputArgs.Width)
-		}
-		if req.InputArgs.Height != 1024 {
-			t.Errorf("expected height 1024, got %d", req.InputArgs.Height)
+		if _, ok := raw["model"]; ok {
+			t.Error("request body contains model field, expected none for z-image-turbo")
 		}
 
-		w.Header().Set("Content-Type", "image/jpeg")
+		var req struct {
+			Prompt string `json:"prompt"`
+			Width  int    `json:"width"`
+			Height int    `json:"height"`
+		}
+		if err := json.Unmarshal(mustMarshal(t, raw), &req); err != nil {
+			t.Fatalf("unmarshal flat body: %v", err)
+		}
+		if req.Prompt != "a cute cat" {
+			t.Errorf("expected prompt 'a cute cat', got %s", req.Prompt)
+		}
+		if req.Width != 1024 {
+			t.Errorf("expected width 1024, got %d", req.Width)
+		}
+		if req.Height != 1024 {
+			t.Errorf("expected height 1024, got %d", req.Height)
+		}
+
+		w.Header().Set("Content-Type", "image/png")
 		w.Write(fakeImage)
 	}))
 	defer srv.Close()
 
-	c := NewChutes("test", srv.URL, "test-key")
+	c := NewChutes("test", srv.URL, "", "test-key")
 
 	result, err := c.Generate(context.Background(), "a cute cat")
 	if err != nil {
@@ -64,6 +74,62 @@ func TestChutes_Generate(t *testing.T) {
 	}
 }
 
+func TestChutes_GenerateWithModel(t *testing.T) {
+	fakeImage := []byte("fake-jpeg-image-data")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var raw map[string]json.RawMessage
+		if err := json.NewDecoder(r.Body).Decode(&raw); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if _, ok := raw["input_args"]; ok {
+			t.Error("request body contains input_args wrapper, expected flat body")
+		}
+
+		var model string
+		if m, ok := raw["model"]; ok {
+			if err := json.Unmarshal(m, &model); err != nil {
+				t.Fatalf("unmarshal model: %v", err)
+			}
+		}
+		if model != "FLUX.1-schnell" {
+			t.Errorf("expected model 'FLUX.1-schnell', got %q", model)
+		}
+
+		var prompt string
+		if err := json.Unmarshal(raw["prompt"], &prompt); err != nil {
+			t.Fatalf("unmarshal prompt: %v", err)
+		}
+		if prompt != "a cute cat" {
+			t.Errorf("expected prompt 'a cute cat', got %s", prompt)
+		}
+
+		w.Header().Set("Content-Type", "image/jpeg")
+		w.Write(fakeImage)
+	}))
+	defer srv.Close()
+
+	c := NewChutes("flux", srv.URL, "FLUX.1-schnell", "test-key")
+
+	result, err := c.Generate(context.Background(), "a cute cat")
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if string(result) != string(fakeImage) {
+		t.Errorf("expected %q, got %q", fakeImage, result)
+	}
+}
+
+// mustMarshal re-marshals a map for decoding into a typed struct.
+func mustMarshal(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return b
+}
+
 func TestChutes_GenerateAPIError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
@@ -71,7 +137,7 @@ func TestChutes_GenerateAPIError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewChutes("test", srv.URL, "test-key")
+	c := NewChutes("test", srv.URL, "", "test-key")
 
 	_, err := c.Generate(context.Background(), "bad prompt")
 	if err == nil {
@@ -86,7 +152,7 @@ func TestChutes_GenerateAuthError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewChutes("test", srv.URL, "bad-key")
+	c := NewChutes("test", srv.URL, "", "bad-key")
 
 	_, err := c.Generate(context.Background(), "a cat")
 	if err == nil {
@@ -104,7 +170,7 @@ func TestChutes_GenerateEmptyBody(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewChutes("test", srv.URL, "test-key")
+	c := NewChutes("test", srv.URL, "", "test-key")
 
 	_, err := c.Generate(context.Background(), "a cat")
 	if err == nil {


### PR DESCRIPTION
## Summary

- Replace nested `input_args` request body with flat JSON format matching the actual Chutes.ai API
- Fix UUID-based URLs with correct provider-specific endpoints (slug-based subdomain for z-image-turbo, shared image endpoint for flux)
- Add `model` config field for image providers (required by flux/FLUX.1-schnell)

**Breaking:** existing `config.json` image provider URLs must be updated.

## Test plan

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] `TestChutes_Generate` verifies flat body without model (z-image-turbo pattern)
- [x] `TestChutes_GenerateWithModel` verifies flat body with model (flux pattern)
- [x] No `input_args` wrapper in any request body
- [ ] Manual test: generate image via z-image-turbo provider
- [ ] Manual test: generate image via flux provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)