### PR TITLE
fix(telegram): use Telegram-allowed emoji for message reactions

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -127,7 +127,7 @@ The document stays in conversation history. You can ask follow-up questions with
 
 ## Message Reactions
 
-Herald reacts to your messages with emoji to show processing status. An hourglass appears when your message is received, replaced by a checkmark when the response is complete or a cross-mark if something went wrong. This works automatically with text messages, photos, and documents. No configuration needed. In group chats where the bot lacks reaction permissions, reactions are silently skipped.
+Herald reacts to your messages with emoji to show processing status. An eyes reaction appears when your message is received, replaced by a thumbs up when the response is complete or a thumbs down if something went wrong. This works automatically with text messages, photos, and documents. No configuration needed. In group chats where the bot lacks reaction permissions, reactions are silently skipped.
 
 ## Streaming Responses
 

--- a/internal/telegram/adapter.go
+++ b/internal/telegram/adapter.go
@@ -21,6 +21,12 @@ import (
 	"github.com/sgraczyk/herald/internal/provider"
 )
 
+const (
+	reactionProcessing = "\U0001f440" // eyes
+	reactionSuccess    = "\U0001f44d" // thumbs up
+	reactionError      = "\U0001f44e" // thumbs down
+)
+
 // knownCommands is the set of commands handled by the agent loop.
 // Keep in sync with the switch in agent.Loop.handle (internal/agent/loop.go).
 // Unknown commands keep full original text so the LLM sees the user's intent.
@@ -135,7 +141,7 @@ func (a *Adapter) handleUpdate(ctx context.Context, b *bot.Bot, update *models.U
 		return
 	}
 
-	a.setReaction(ctx, chatID, msg.ID, "\u23f3")
+	a.setReaction(ctx, chatID, msg.ID, reactionProcessing)
 	a.mu.Lock()
 	a.reactionMsgs[chatID] = msg.ID
 	a.mu.Unlock()
@@ -145,7 +151,7 @@ func (a *Adapter) handleUpdate(ctx context.Context, b *bot.Bot, update *models.U
 }
 
 func (a *Adapter) handlePhoto(ctx context.Context, b *bot.Bot, msg *models.Message, chatID, userID int64) {
-	a.setReaction(ctx, chatID, msg.ID, "\u23f3")
+	a.setReaction(ctx, chatID, msg.ID, reactionProcessing)
 	a.mu.Lock()
 	a.reactionMsgs[chatID] = msg.ID
 	a.mu.Unlock()
@@ -201,7 +207,7 @@ func (a *Adapter) handlePhoto(ctx context.Context, b *bot.Bot, msg *models.Messa
 
 	if a.hub.Draining() {
 		slog.Debug("dropping photo message, hub is draining", slog.Int64("chat_id", chatID))
-		a.completeReaction(ctx, chatID, "\u274c")
+		a.completeReaction(ctx, chatID, reactionError)
 		return
 	}
 
@@ -218,7 +224,7 @@ func (a *Adapter) handlePhoto(ctx context.Context, b *bot.Bot, msg *models.Messa
 const maxDocumentSize = 10 << 20 // 10 MB
 
 func (a *Adapter) handleDocument(ctx context.Context, b *bot.Bot, msg *models.Message, chatID, userID int64) {
-	a.setReaction(ctx, chatID, msg.ID, "\u23f3")
+	a.setReaction(ctx, chatID, msg.ID, reactionProcessing)
 	a.mu.Lock()
 	a.reactionMsgs[chatID] = msg.ID
 	a.mu.Unlock()
@@ -280,7 +286,7 @@ func (a *Adapter) handleDocument(ctx context.Context, b *bot.Bot, msg *models.Me
 
 	if a.hub.Draining() {
 		slog.Debug("dropping document message, hub is draining", slog.Int64("chat_id", chatID))
-		a.completeReaction(ctx, chatID, "\u274c")
+		a.completeReaction(ctx, chatID, reactionError)
 		return
 	}
 
@@ -313,7 +319,7 @@ func documentErrorMessage(err error) string {
 }
 
 func (a *Adapter) sendError(ctx context.Context, chatID int64, text string) {
-	a.completeReaction(ctx, chatID, "\u274c")
+	a.completeReaction(ctx, chatID, reactionError)
 
 	_, err := a.bot.SendMessage(ctx, &bot.SendMessageParams{
 		ChatID: chatID,
@@ -379,9 +385,9 @@ func (a *Adapter) dispatchOut(ctx context.Context) {
 				}
 			}
 			if sendFailed {
-				a.completeReaction(ctx, msg.ChatID, "\u274c")
+				a.completeReaction(ctx, msg.ChatID, reactionError)
 			} else {
-				a.completeReaction(ctx, msg.ChatID, "\u2705")
+				a.completeReaction(ctx, msg.ChatID, reactionSuccess)
 			}
 		}
 	}
@@ -412,7 +418,7 @@ func (a *Adapter) dispatchStream(ctx context.Context) {
 
 			// Error case: empty text + done means delete in-progress message.
 			if update.Text == "" && update.Done {
-				a.completeReaction(ctx, update.ChatID, "\u274c")
+				a.completeReaction(ctx, update.ChatID, reactionError)
 				if exists {
 					_, err := a.bot.DeleteMessage(ctx, &bot.DeleteMessageParams{
 						ChatID:    update.ChatID,
@@ -500,7 +506,7 @@ func (a *Adapter) dispatchStream(ctx context.Context) {
 				delete(a.streamMsgs, update.ChatID)
 				a.mu.Unlock()
 
-				a.completeReaction(ctx, update.ChatID, "\u2705")
+				a.completeReaction(ctx, update.ChatID, reactionSuccess)
 			}
 		}
 	}
@@ -520,9 +526,9 @@ func (a *Adapter) dispatchImage(ctx context.Context) {
 			})
 			if err != nil {
 				slog.Error("send photo failed", slog.Int64("chat_id", img.ChatID), slog.String("error", err.Error()))
-				a.completeReaction(ctx, img.ChatID, "\u274c")
+				a.completeReaction(ctx, img.ChatID, reactionError)
 			} else {
-				a.completeReaction(ctx, img.ChatID, "\u2705")
+				a.completeReaction(ctx, img.ChatID, reactionSuccess)
 			}
 		}
 	}

--- a/internal/telegram/adapter_test.go
+++ b/internal/telegram/adapter_test.go
@@ -358,7 +358,7 @@ func TestCompleteReactionClearsMap(t *testing.T) {
 	a.reactionMsgs[42] = 77
 	a.mu.Unlock()
 
-	a.completeReaction(context.Background(), 42, "\u2705")
+	a.completeReaction(context.Background(), 42, reactionSuccess)
 
 	a.mu.Lock()
 	_, ok := a.reactionMsgs[42]
@@ -373,7 +373,7 @@ func TestCompleteReactionNoOpWhenNoEntry(t *testing.T) {
 	a, _ := testAdapter(t, map[int64]bool{111: true})
 
 	// Should not panic when no entry exists.
-	a.completeReaction(context.Background(), 42, "\u2705")
+	a.completeReaction(context.Background(), 42, reactionSuccess)
 
 	a.mu.Lock()
 	_, ok := a.reactionMsgs[42]
@@ -391,7 +391,7 @@ func TestCompleteReactionCrossMarkClearsMap(t *testing.T) {
 	a.reactionMsgs[42] = 77
 	a.mu.Unlock()
 
-	a.completeReaction(context.Background(), 42, "\u274c")
+	a.completeReaction(context.Background(), 42, reactionError)
 
 	a.mu.Lock()
 	_, ok := a.reactionMsgs[42]


### PR DESCRIPTION
## Summary

- Replace hourglass/checkmark/cross mark emoji with eyes/thumbs up/thumbs down — Telegram's default allowed reaction set
- Fixes `REACTION_INVALID` errors that made reactions non-functional in private chats
- Extract emoji into named constants (`reactionProcessing`, `reactionSuccess`, `reactionError`)

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [ ] Manual test: send message in private chat, observe 👀 during processing, 👍 on completion
- [ ] Verify no `REACTION_INVALID` errors in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)