### PR TITLE
feat(tool): extensible tool framework with provider integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ Thumbs.db
 # Superpowers (specs, plans)
 docs/superpowers/
 
+# Worktrees
+.worktrees/
+
 # Playwright
 .playwright-mcp/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,9 @@ Telegram ──write──> Hub.In ──read──> Agent Loop ──call──
                                          │
                                          ├──read/write──> Store (bbolt)
                                          │
+                                         ├──call──> Tool Registry ──dispatch──> Tool.Execute (90s timeout)
+                                         │              (max 3 calls per message, results fed back to provider)
+                                         │
                                          ├──write──> Hub.Stream ──read──> Telegram (edit-in-place, plain text)
                                          │
                                          ├──write──> Hub.Image ──read──> Telegram (send photo)
@@ -96,6 +99,10 @@ internal/
     memory.go                # Long-term memory per chat (facts, preferences)
     summary.go               # Conversation summary per chat (pre-prune condensation)
     conversation.go          # Conversation archival and listing
+  tool/
+    tool.go                  # Tool interface, Parameter, Result, ToolCall, Registry
+    prompt.go                # PromptCaller: XML tool definition injection + response parsing
+    image.go                 # ImageTool adapter wrapping ImageProvider
   telegram/
     adapter.go               # go-telegram/bot long-polling, user whitelist
 docs/

--- a/cmd/herald/main.go
+++ b/cmd/herald/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sgraczyk/herald/internal/provider"
 	"github.com/sgraczyk/herald/internal/store"
 	"github.com/sgraczyk/herald/internal/telegram"
+	"github.com/sgraczyk/herald/internal/tool"
 )
 
 var version = "dev"
@@ -141,8 +142,15 @@ func serve(configPath string) error {
 	// Create hub.
 	h := hub.New()
 
+	// Create tool registry and register image generation if available.
+	var registry *tool.Registry
+	if imgProvider != nil {
+		registry = tool.NewRegistry()
+		registry.Register(tool.NewImageTool(imgProvider))
+	}
+
 	// Create agent loop.
-	loop := agent.NewLoop(h, chain, db, cfg.HistoryLimit, cfg.HistoryTokenBudget, *cfg.MaxArchivedConversations, cfg.Summarize, cfg.Streaming, cfg.SystemPrompt, m, imgProvider, cfg.StatusMessages)
+	loop := agent.NewLoop(h, chain, db, cfg.HistoryLimit, cfg.HistoryTokenBudget, *cfg.MaxArchivedConversations, cfg.Summarize, cfg.Streaming, cfg.SystemPrompt, m, registry, cfg.StatusMessages)
 
 	// Create Telegram adapter.
 	tg, err := telegram.New(cfg.Telegram.Token, h, cfg.AllowedUserIDs, document.NewPDFExtractor(cfg.MaxDocumentTokens))

--- a/cmd/herald/main.go
+++ b/cmd/herald/main.go
@@ -104,14 +104,10 @@ func serve(configPath string) error {
 	}
 	provider.ValidateProviders(context.Background(), providers)
 
-	// Create metrics.
 	providerNames := make([]string, len(providers))
 	for i, p := range providers {
 		providerNames[i] = p.Name()
 	}
-	m := metrics.New(providerNames, nil)
-
-	chain := provider.NewFallback(providers, *cfg.MaxRetries, m)
 
 	// Build image providers.
 	var imgProviders []provider.ImageProvider
@@ -142,12 +138,25 @@ func serve(configPath string) error {
 	// Create hub.
 	h := hub.New()
 
-	// Create tool registry and register image generation if available.
-	var registry *tool.Registry
+	// Build tool registry.
+	registry := tool.NewRegistry()
 	if imgProvider != nil {
-		registry = tool.NewRegistry()
-		registry.Register(tool.NewImageTool(imgProvider))
+		if err := registry.Register(tool.NewImageTool(imgProvider)); err != nil {
+			return fmt.Errorf("register image tool: %w", err)
+		}
 	}
+	for _, t := range registry.All() {
+		slog.Info("tool registered", slog.String("name", t.Name()))
+	}
+
+	// Create metrics with provider and tool names.
+	toolNames := make([]string, 0)
+	for _, t := range registry.All() {
+		toolNames = append(toolNames, t.Name())
+	}
+	m := metrics.New(providerNames, toolNames)
+
+	chain := provider.NewFallback(providers, *cfg.MaxRetries, m)
 
 	// Create agent loop.
 	loop := agent.NewLoop(h, chain, db, cfg.HistoryLimit, cfg.HistoryTokenBudget, *cfg.MaxArchivedConversations, cfg.Summarize, cfg.Streaming, cfg.SystemPrompt, m, registry, cfg.StatusMessages)

--- a/cmd/herald/main.go
+++ b/cmd/herald/main.go
@@ -108,7 +108,7 @@ func serve(configPath string) error {
 	for i, p := range providers {
 		providerNames[i] = p.Name()
 	}
-	m := metrics.New(providerNames)
+	m := metrics.New(providerNames, nil)
 
 	chain := provider.NewFallback(providers, *cfg.MaxRetries, m)
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -93,7 +93,7 @@ With streaming enabled, if the LLM decides to generate an image mid-stream, Hera
 - **Chutes.ai only.** Other providers can be added by implementing the `ImageProvider` interface.
 - **Fixed size.** All generated images are 1024x1024.
 - **20 MB upload limit.** Images exceeding Telegram's limit are rejected.
-- **60-second timeout.** Image generation requests time out after 60 seconds.
+- **90-second timeout.** Image generation requests time out after 90 seconds.
 - **Paid API.** Image generation incurs costs on your Chutes.ai account.
 
 ## PDF Document Support

--- a/internal/agent/context.go
+++ b/internal/agent/context.go
@@ -16,26 +16,6 @@ Formatting rules for Telegram:
 - Use bold, italic, and code blocks for emphasis.
 - Keep messages concise — users read on mobile.`
 
-const imageToolPrompt = `
-
-You have access to the following tool:
-
-<tool>
-<name>generate_image</name>
-<description>Generate an image from a text description. Use this when the user asks you to draw, create, generate, or make an image or picture.</description>
-<parameters>
-<parameter name="prompt" type="string" required="true">A detailed description of the image to generate.</parameter>
-</parameters>
-</tool>
-
-When you want to generate an image, respond with this XML block:
-<tool_use>
-<name>generate_image</name>
-<parameters>
-<prompt>your detailed image prompt here</prompt>
-</parameters>
-</tool_use>`
-
 // maxContextMemories limits how many memories are injected into the system
 // prompt. All explicit memories are always included; remaining slots are
 // filled with the most recent auto-extracted memories.
@@ -43,8 +23,8 @@ const maxContextMemories = 50
 
 // buildMessages assembles the full message list for the provider:
 // system prompt (with summary and memories) + conversation history + current user message.
-// If hasImageGen is true, the generate_image tool definition is appended to the system prompt.
-func buildMessages(history []provider.Message, memories []store.Memory, userText, customPrompt, summary string, hasImageGen bool) []provider.Message {
+// If toolPrompt is non-empty, it is appended to the system prompt (tool definitions).
+func buildMessages(history []provider.Message, memories []store.Memory, userText, customPrompt, summary, toolPrompt string) []provider.Message {
 	msgs := make([]provider.Message, 0, len(history)+2)
 
 	selected := selectMemories(memories)
@@ -52,8 +32,8 @@ func buildMessages(history []provider.Message, memories []store.Memory, userText
 	if customPrompt != "" {
 		prompt = customPrompt
 	}
-	if hasImageGen {
-		prompt += imageToolPrompt
+	if toolPrompt != "" {
+		prompt += toolPrompt
 	}
 	if summary != "" {
 		prompt += "\n\nSummary of earlier conversation:\n" + summary

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -453,13 +453,26 @@ func (l *Loop) handleMessage(ctx context.Context, msg hub.InMessage) {
 					// detected a tool call, so we just need to execute it.
 					if l.hasTools() {
 						if tc := l.promptCaller.Parse(response); tc != nil {
-							text, execErr := l.executeToolCalls(ctx, msg, messages, response)
+							text, intermediates, execErr := l.executeToolCalls(ctx, msg, messages, response)
 							if execErr != nil {
-								l.hub.Out <- hub.OutMessage{ChatID: msg.ChatID, Text: l.statusMessages.ProvGenericErr}
+								if l.metrics != nil {
+									l.metrics.IncFailed()
+								}
+								slog.Error("tool execution failed", slog.Int64("chat_id", msg.ChatID), slog.String("error", execErr.Error()))
+								var errText string
+								switch {
+								case errors.Is(execErr, provider.ErrTimeout):
+									errText = l.statusMessages.ProvTimeout
+								case errors.Is(execErr, provider.ErrAuthFailure):
+									errText = l.statusMessages.ProvAuthError
+								default:
+									errText = l.statusMessages.ProvGenericErr
+								}
+								l.hub.Out <- hub.OutMessage{ChatID: msg.ChatID, Text: errText}
 								return
 							}
 							if text != "" {
-								l.saveAndRespond(msg, text)
+								l.saveAndRespond(msg, text, intermediates...)
 							}
 							// When text is empty, executeToolCalls already handled save + routing.
 							return
@@ -481,7 +494,7 @@ func (l *Loop) handleMessage(ctx context.Context, msg hub.InMessage) {
 
 	// Tool execution path: use executeToolCalls when tools are registered.
 	if l.hasTools() {
-		text, execErr := l.executeToolCalls(ctx, msg, messages, "")
+		text, intermediates, execErr := l.executeToolCalls(ctx, msg, messages, "")
 		if execErr != nil {
 			if l.metrics != nil {
 				l.metrics.IncFailed()
@@ -500,7 +513,7 @@ func (l *Loop) handleMessage(ctx context.Context, msg hub.InMessage) {
 			return
 		}
 		if text != "" {
-			l.saveAndRespond(msg, text)
+			l.saveAndRespond(msg, text, intermediates...)
 		}
 		// When text is empty, executeToolCalls already called saveAndProcess
 		// and routed the binary result (e.g., image).
@@ -531,16 +544,19 @@ func (l *Loop) handleMessage(ctx context.Context, msg hub.InMessage) {
 
 // saveAndRespond saves messages to store, sends the response via hub.Out,
 // and triggers background memory extraction and summarization.
-func (l *Loop) saveAndRespond(msg hub.InMessage, response string) {
-	l.saveAndProcess(msg, response)
+// Optional intermediates are tool-call exchange messages to persist between
+// the user message and the final assistant response.
+func (l *Loop) saveAndRespond(msg hub.InMessage, response string, intermediates ...provider.Message) {
+	l.saveAndProcess(msg, response, intermediates...)
 	l.hub.Out <- hub.OutMessage{ChatID: msg.ChatID, Text: response}
 }
 
 // saveAndProcess saves messages to store and triggers background memory
 // extraction and summarization. Unlike saveAndRespond, it does NOT send the
 // response to hub.Out — use this when the response was already delivered
-// (e.g., via streaming).
-func (l *Loop) saveAndProcess(msg hub.InMessage, response string) {
+// (e.g., via streaming). Optional intermediates are tool-call exchange
+// messages persisted between the user message and the final assistant response.
+func (l *Loop) saveAndProcess(msg hub.InMessage, response string, intermediates ...provider.Message) {
 	// Save document as a system-role history message before the user message.
 	if msg.Document != nil {
 		docMsg := provider.Message{
@@ -568,6 +584,13 @@ func (l *Loop) saveAndProcess(msg hub.InMessage, response string) {
 	}
 	if err := l.store.Append(msg.ChatID, userMsg, l.historyLimit); err != nil {
 		slog.Error("save user message failed", slog.Int64("chat_id", msg.ChatID), slog.String("error", err.Error()))
+	}
+
+	// Save intermediate tool-call exchanges (assistant tool call + tool result).
+	for _, im := range intermediates {
+		if err := l.store.Append(msg.ChatID, im, l.historyLimit); err != nil {
+			slog.Error("save intermediate message failed", slog.Int64("chat_id", msg.ChatID), slog.String("role", im.Role), slog.String("error", err.Error()))
+		}
 	}
 
 	// Save assistant response.
@@ -679,7 +702,8 @@ const (
 // is parsed for a tool call directly (used when streaming already obtained a
 // response). Returns the final text response, or ("", nil) when the result was
 // a binary payload already delivered (e.g., image).
-func (l *Loop) executeToolCalls(ctx context.Context, msg hub.InMessage, messages []provider.Message, initialResponse string) (string, error) {
+func (l *Loop) executeToolCalls(ctx context.Context, msg hub.InMessage, messages []provider.Message, initialResponse string) (string, []provider.Message, error) {
+	var intermediates []provider.Message
 	for i := 0; i < maxToolCalls; i++ {
 		var response string
 		var tc *tool.ToolCall
@@ -693,7 +717,7 @@ func (l *Loop) executeToolCalls(ctx context.Context, msg hub.InMessage, messages
 			// Call the LLM.
 			resp, err := l.provider.Chat(ctx, messages)
 			if err != nil {
-				return "", err
+				return "", nil, err
 			}
 			response = resp
 
@@ -705,14 +729,14 @@ func (l *Loop) executeToolCalls(ctx context.Context, msg hub.InMessage, messages
 
 		// No tool call — pure text response.
 		if tc == nil {
-			return response, nil
+			return response, intermediates, nil
 		}
 
 		// Look up tool in registry.
 		t, ok := l.registry.Get(tc.Name)
 		if !ok {
 			slog.Warn("LLM requested unknown tool", slog.String("tool", tc.Name))
-			return response, nil
+			return response, intermediates, nil
 		}
 
 		slog.Info("tool call", slog.String("tool", tc.Name), slog.Int64("chat_id", msg.ChatID))
@@ -755,7 +779,7 @@ func (l *Loop) executeToolCalls(ctx context.Context, msg hub.InMessage, messages
 					errText = l.statusMessages.ImageGenericErr
 				}
 				l.hub.Out <- hub.OutMessage{ChatID: msg.ChatID, Text: errText}
-				return "", nil
+				return "", nil, nil
 			}
 
 			// For other tools, feed error back to the LLM.
@@ -769,15 +793,15 @@ func (l *Loop) executeToolCalls(ctx context.Context, msg hub.InMessage, messages
 		// Route binary data (e.g., images).
 		if result.Data != nil {
 			l.routeBinaryResult(msg, tc.Name, result)
-			l.saveAndProcess(msg, response)
-			return "", nil
+			l.saveAndProcess(msg, response, intermediates...)
+			return "", nil, nil
 		}
 
 		// Feed text result back to the LLM for the next iteration.
-		messages = append(messages,
-			provider.Message{Role: "assistant", Content: response},
-			provider.Message{Role: "user", Content: fmt.Sprintf("Tool result for %q: %s", tc.Name, result.Text)},
-		)
+		assistantMsg := provider.Message{Role: "assistant", Content: response, Timestamp: time.Now()}
+		toolResultMsg := provider.Message{Role: "user", Content: fmt.Sprintf("Tool result for %q: %s", tc.Name, result.Text), Timestamp: time.Now()}
+		messages = append(messages, assistantMsg, toolResultMsg)
+		intermediates = append(intermediates, assistantMsg, toolResultMsg)
 	}
 
 	// Max iterations hit — ask LLM to produce a final answer.
@@ -787,9 +811,9 @@ func (l *Loop) executeToolCalls(ctx context.Context, msg hub.InMessage, messages
 	})
 	response, err := l.provider.Chat(ctx, messages)
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
-	return response, nil
+	return response, intermediates, nil
 }
 
 // routeBinaryResult delivers binary tool output (e.g., generated images) to

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -670,8 +670,9 @@ const (
 	// before forcing a final text response from the LLM.
 	maxToolCalls = 3
 
-	// toolCallTimeout is the per-tool execution timeout.
-	toolCallTimeout = 10 * time.Second
+	// toolCallTimeout is the per-tool execution timeout. Set above the
+	// image provider's 60-second HTTP timeout to avoid premature cancellation.
+	toolCallTimeout = 90 * time.Second
 )
 
 // executeToolCalls runs the tool call loop. If initialResponse is non-empty, it

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -18,6 +17,7 @@ import (
 	"github.com/sgraczyk/herald/internal/metrics"
 	"github.com/sgraczyk/herald/internal/provider"
 	"github.com/sgraczyk/herald/internal/store"
+	"github.com/sgraczyk/herald/internal/tool"
 )
 
 // Loop reads messages from the hub, calls the provider, and writes responses back.
@@ -25,7 +25,8 @@ type Loop struct {
 	hub                      *hub.Hub
 	provider                 provider.LLMProvider
 	extProvider              provider.LLMProvider // provider used for memory extraction and summarization
-	imageProvider            provider.ImageProvider
+	registry                 *tool.Registry
+	promptCaller             *tool.PromptCaller
 	store                    *store.DB
 	metrics                  *metrics.Metrics
 	historyLimit             int
@@ -47,11 +48,12 @@ type Loop struct {
 // before pruning. When streaming is true, providers that implement
 // StreamingProvider are used for incremental response delivery. The
 // maxArchived parameter limits how many archived conversations are kept per
-// chat (0 disables pruning, keeping all archives). The imgProvider parameter
-// is optional; when non-nil, the LLM is informed about the generate_image tool.
+// chat (0 disables pruning, keeping all archives). The registry parameter
+// is optional; when non-nil with registered tools, the LLM is informed about
+// available tools via prompt injection or native function calling.
 // The sm parameter provides configurable status messages; when nil, defaults
 // from config loading are used.
-func NewLoop(h *hub.Hub, p provider.LLMProvider, s *store.DB, historyLimit, tokenBudget, maxArchived int, summarize, streaming bool, systemPrompt string, m *metrics.Metrics, imgProvider provider.ImageProvider, sm *config.StatusMessages) *Loop {
+func NewLoop(h *hub.Hub, p provider.LLMProvider, s *store.DB, historyLimit, tokenBudget, maxArchived int, summarize, streaming bool, systemPrompt string, m *metrics.Metrics, registry *tool.Registry, sm *config.StatusMessages) *Loop {
 	if sm == nil {
 		sm = &config.StatusMessages{
 			ImageGenerating: "Generating image...",
@@ -64,11 +66,16 @@ func NewLoop(h *hub.Hub, p provider.LLMProvider, s *store.DB, historyLimit, toke
 			ProvGenericErr:  "I'm temporarily unavailable. Please try again shortly.",
 		}
 	}
+	var pc *tool.PromptCaller
+	if registry != nil {
+		pc = tool.NewPromptCaller(registry)
+	}
 	return &Loop{
 		hub:                      h,
 		provider:                 p,
 		extProvider:              pickExtractionProvider(p),
-		imageProvider:            imgProvider,
+		registry:                 registry,
+		promptCaller:             pc,
 		store:                    s,
 		metrics:                  m,
 		historyLimit:             historyLimit,
@@ -371,6 +378,20 @@ func firstUserPreview(msgs []provider.Message) string {
 	return ""
 }
 
+// hasTools reports whether any tools are registered.
+func (l *Loop) hasTools() bool {
+	return l.registry != nil && len(l.registry.All()) > 0
+}
+
+// toolPromptFragment returns the XML tool definitions to append to the system
+// prompt, or "" if no tools are registered.
+func (l *Loop) toolPromptFragment() string {
+	if l.promptCaller == nil {
+		return ""
+	}
+	return l.promptCaller.PromptFragment()
+}
+
 func (l *Loop) handleMessage(ctx context.Context, msg hub.InMessage) {
 	if l.metrics != nil {
 		l.metrics.IncReceived()
@@ -399,7 +420,7 @@ func (l *Loop) handleMessage(ctx context.Context, msg hub.InMessage) {
 	l.hub.Typing <- msg.ChatID
 
 	// Build messages and call provider.
-	messages := buildMessages(history, memories, msg.Text, l.systemPrompt, summary, l.imageProvider != nil)
+	messages := buildMessages(history, memories, msg.Text, l.systemPrompt, summary, l.toolPromptFragment())
 
 	// Inject document context as a system message just before the user message.
 	if msg.Document != nil {
@@ -427,10 +448,20 @@ func (l *Loop) handleMessage(ctx context.Context, msg hub.InMessage) {
 			if sp, ok := fb.Active().(provider.StreamingProvider); ok {
 				response, streamErr := l.handleStream(ctx, sp, messages, msg.ChatID)
 				if streamErr == nil {
-					// Check for image generation tool call in streamed response.
-					if l.imageProvider != nil {
-						if prompt, ok := parseImageToolCall(response); ok {
-							l.handleImageGeneration(ctx, msg, prompt, response)
+					// Check for tool call in streamed response.
+					// handleStream already deleted the streamed message if it
+					// detected a tool call, so we just need to execute it.
+					if l.hasTools() {
+						if tc := l.promptCaller.Parse(response); tc != nil {
+							text, execErr := l.executeToolCalls(ctx, msg, messages, response)
+							if execErr != nil {
+								l.hub.Out <- hub.OutMessage{ChatID: msg.ChatID, Text: l.statusMessages.ProvGenericErr}
+								return
+							}
+							if text != "" {
+								l.saveAndRespond(msg, text)
+							}
+							// When text is empty, executeToolCalls already handled save + routing.
 							return
 						}
 					}
@@ -446,6 +477,34 @@ func (l *Loop) handleMessage(ctx context.Context, msg hub.InMessage) {
 				// Fall through to buffered Chat().
 			}
 		}
+	}
+
+	// Tool execution path: use executeToolCalls when tools are registered.
+	if l.hasTools() {
+		text, execErr := l.executeToolCalls(ctx, msg, messages, "")
+		if execErr != nil {
+			if l.metrics != nil {
+				l.metrics.IncFailed()
+			}
+			slog.Error("tool execution failed", slog.Int64("chat_id", msg.ChatID), slog.String("error", execErr.Error()))
+			var errText string
+			switch {
+			case errors.Is(execErr, provider.ErrTimeout):
+				errText = l.statusMessages.ProvTimeout
+			case errors.Is(execErr, provider.ErrAuthFailure):
+				errText = l.statusMessages.ProvAuthError
+			default:
+				errText = l.statusMessages.ProvGenericErr
+			}
+			l.hub.Out <- hub.OutMessage{ChatID: msg.ChatID, Text: errText}
+			return
+		}
+		if text != "" {
+			l.saveAndRespond(msg, text)
+		}
+		// When text is empty, executeToolCalls already called saveAndProcess
+		// and routed the binary result (e.g., image).
+		return
 	}
 
 	response, err := l.provider.Chat(ctx, messages)
@@ -465,14 +524,6 @@ func (l *Loop) handleMessage(ctx context.Context, msg hub.InMessage) {
 		}
 		l.hub.Out <- hub.OutMessage{ChatID: msg.ChatID, Text: errText}
 		return
-	}
-
-	// Check for image generation tool call.
-	if l.imageProvider != nil {
-		if prompt, ok := parseImageToolCall(response); ok {
-			l.handleImageGeneration(ctx, msg, prompt, response)
-			return
-		}
 	}
 
 	l.saveAndRespond(msg, response)
@@ -592,10 +643,10 @@ func (l *Loop) handleStream(ctx context.Context, sp provider.StreamingProvider, 
 		return "", err
 	}
 
-	// If the response contains an image tool call, delete the streamed
-	// message (which would contain raw XML) instead of finalizing it.
-	if l.imageProvider != nil {
-		if _, ok := parseImageToolCall(response); ok {
+	// If the response contains a tool call, delete the streamed message
+	// (which would contain raw XML) instead of finalizing it.
+	if l.hasTools() {
+		if tc := l.promptCaller.Parse(response); tc != nil {
 			l.hub.Stream <- hub.StreamUpdate{ChatID: chatID, Text: "", Done: true}
 			return response, nil
 		}
@@ -614,61 +665,146 @@ func (l *Loop) handleStream(ctx context.Context, sp provider.StreamingProvider, 
 // maxImageSize is the maximum image size Telegram accepts (20 MB).
 const maxImageSize = 20 << 20
 
-// imageToolCallRe matches the XML tool_use block for generate_image.
-var imageToolCallRe = regexp.MustCompile(`(?s)<tool_use>\s*<name>generate_image</name>\s*<parameters>\s*<prompt>(.*?)</prompt>\s*</parameters>\s*</tool_use>`)
+const (
+	// maxToolCalls limits how many tool call iterations the agent loop performs
+	// before forcing a final text response from the LLM.
+	maxToolCalls = 3
 
-// parseImageToolCall checks if the LLM response contains a generate_image
-// tool call and returns the prompt. Returns ("", false) if no tool call found.
-func parseImageToolCall(response string) (string, bool) {
-	matches := imageToolCallRe.FindStringSubmatch(response)
-	if len(matches) < 2 {
-		return "", false
+	// toolCallTimeout is the per-tool execution timeout.
+	toolCallTimeout = 10 * time.Second
+)
+
+// executeToolCalls runs the tool call loop. If initialResponse is non-empty, it
+// is parsed for a tool call directly (used when streaming already obtained a
+// response). Returns the final text response, or ("", nil) when the result was
+// a binary payload already delivered (e.g., image).
+func (l *Loop) executeToolCalls(ctx context.Context, msg hub.InMessage, messages []provider.Message, initialResponse string) (string, error) {
+	for i := 0; i < maxToolCalls; i++ {
+		var response string
+		var tc *tool.ToolCall
+
+		if initialResponse != "" {
+			// First iteration when streaming already got a response.
+			response = initialResponse
+			tc = l.promptCaller.Parse(response)
+			initialResponse = "" // only use once
+		} else {
+			// Call the LLM.
+			resp, err := l.provider.Chat(ctx, messages)
+			if err != nil {
+				return "", err
+			}
+			response = resp
+
+			// Check for tool call.
+			if l.promptCaller != nil {
+				tc = l.promptCaller.Parse(response)
+			}
+		}
+
+		// No tool call — pure text response.
+		if tc == nil {
+			return response, nil
+		}
+
+		// Look up tool in registry.
+		t, ok := l.registry.Get(tc.Name)
+		if !ok {
+			slog.Warn("LLM requested unknown tool", slog.String("tool", tc.Name))
+			return response, nil
+		}
+
+		slog.Info("tool call", slog.String("tool", tc.Name), slog.Int64("chat_id", msg.ChatID))
+
+		// For generate_image: send placeholder and typing indicator.
+		if tc.Name == "generate_image" {
+			l.hub.Out <- hub.OutMessage{ChatID: msg.ChatID, Text: l.statusMessages.ImageGenerating}
+			l.hub.Typing <- msg.ChatID
+		}
+
+		// Execute the tool.
+		if l.metrics != nil {
+			l.metrics.IncToolCall(tc.Name)
+		}
+		toolCtx, cancel := context.WithTimeout(ctx, toolCallTimeout)
+		start := time.Now()
+		result, execErr := t.Execute(toolCtx, tc.Args)
+		elapsed := time.Since(start)
+		cancel()
+
+		if l.metrics != nil {
+			l.metrics.ObserveToolLatency(tc.Name, elapsed)
+		}
+
+		if execErr != nil {
+			if l.metrics != nil {
+				l.metrics.IncToolError(tc.Name)
+			}
+			slog.Error("tool execution failed", slog.String("tool", tc.Name), slog.Int64("chat_id", msg.ChatID), slog.String("error", execErr.Error()))
+
+			// For generate_image, use specific status messages.
+			if tc.Name == "generate_image" {
+				var errText string
+				switch {
+				case errors.Is(execErr, provider.ErrTimeout):
+					errText = l.statusMessages.ImageTimeout
+				case errors.Is(execErr, provider.ErrAuthFailure):
+					errText = l.statusMessages.ImageAuthError
+				default:
+					errText = l.statusMessages.ImageGenericErr
+				}
+				l.hub.Out <- hub.OutMessage{ChatID: msg.ChatID, Text: errText}
+				return "", nil
+			}
+
+			// For other tools, feed error back to the LLM.
+			messages = append(messages,
+				provider.Message{Role: "assistant", Content: response},
+				provider.Message{Role: "user", Content: fmt.Sprintf("Tool %q failed: %s", tc.Name, execErr.Error())},
+			)
+			continue
+		}
+
+		// Route binary data (e.g., images).
+		if result.Data != nil {
+			l.routeBinaryResult(msg, tc.Name, result)
+			l.saveAndProcess(msg, response)
+			return "", nil
+		}
+
+		// Feed text result back to the LLM for the next iteration.
+		messages = append(messages,
+			provider.Message{Role: "assistant", Content: response},
+			provider.Message{Role: "user", Content: fmt.Sprintf("Tool result for %q: %s", tc.Name, result.Text)},
+		)
 	}
-	prompt := strings.TrimSpace(matches[1])
-	if prompt == "" {
-		return "", false
+
+	// Max iterations hit — ask LLM to produce a final answer.
+	messages = append(messages, provider.Message{
+		Role:    "system",
+		Content: "Tool call limit reached. Produce a final text response now without calling any tools.",
+	})
+	response, err := l.provider.Chat(ctx, messages)
+	if err != nil {
+		return "", err
 	}
-	return prompt, true
+	return response, nil
 }
 
-// handleImageGeneration sends a placeholder message, generates an image,
-// and delivers it as a Telegram photo.
-func (l *Loop) handleImageGeneration(ctx context.Context, msg hub.InMessage, prompt, llmResponse string) {
-	slog.Info("image generation requested", slog.Int64("chat_id", msg.ChatID), slog.String("prompt", prompt))
-
-	// Send placeholder and re-signal typing for the long generation call.
-	l.hub.Out <- hub.OutMessage{ChatID: msg.ChatID, Text: l.statusMessages.ImageGenerating}
-	l.hub.Typing <- msg.ChatID
-
-	// Generate image.
-	imgBytes, err := l.imageProvider.Generate(ctx, prompt)
-	if err != nil {
-		if l.metrics != nil {
-			l.metrics.IncFailed()
+// routeBinaryResult delivers binary tool output (e.g., generated images) to
+// the appropriate hub channel.
+func (l *Loop) routeBinaryResult(msg hub.InMessage, toolName string, result *tool.Result) {
+	switch toolName {
+	case "generate_image":
+		if len(result.Data) > maxImageSize {
+			slog.Error("generated image too large", slog.Int64("chat_id", msg.ChatID), slog.Int("size", len(result.Data)))
+			l.hub.Out <- hub.OutMessage{ChatID: msg.ChatID, Text: l.statusMessages.ImageTooLarge}
+			return
 		}
-		slog.Error("image generation failed", slog.Int64("chat_id", msg.ChatID), slog.String("error", err.Error()))
-		var errText string
-		switch {
-		case errors.Is(err, provider.ErrTimeout):
-			errText = l.statusMessages.ImageTimeout
-		case errors.Is(err, provider.ErrAuthFailure):
-			errText = l.statusMessages.ImageAuthError
-		default:
-			errText = l.statusMessages.ImageGenericErr
-		}
-		l.hub.Out <- hub.OutMessage{ChatID: msg.ChatID, Text: errText}
-		return
+		l.hub.Image <- hub.ImageMessage{ChatID: msg.ChatID, Data: result.Data}
+	default:
+		slog.Warn("binary result from unhandled tool", slog.String("tool", toolName))
 	}
-
-	if len(imgBytes) > maxImageSize {
-		slog.Error("generated image too large", slog.Int64("chat_id", msg.ChatID), slog.Int("size", len(imgBytes)))
-		l.hub.Out <- hub.OutMessage{ChatID: msg.ChatID, Text: l.statusMessages.ImageTooLarge}
-		return
-	}
-
-	// Save the tool call as the assistant response only after successful generation.
-	l.saveAndProcess(msg, llmResponse)
-	l.hub.Image <- hub.ImageMessage{ChatID: msg.ChatID, Data: imgBytes}
 }
 
 // isTrivialMessage returns true for messages too short to contain memorable content.

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sgraczyk/herald/internal/hub"
 	"github.com/sgraczyk/herald/internal/provider"
 	"github.com/sgraczyk/herald/internal/store"
+	"github.com/sgraczyk/herald/internal/tool"
 )
 
 // mockProvider implements provider.LLMProvider for testing.
@@ -340,7 +341,7 @@ func TestBuildMessagesWithMemories(t *testing.T) {
 		{Fact: "prefers Go", Source: "explicit"},
 	}
 
-	msgs := buildMessages(history, memories, "hello", "", "", false)
+	msgs := buildMessages(history, memories, "hello", "", "", "")
 
 	if len(msgs) != 3 {
 		t.Fatalf("expected 3 messages, got %d", len(msgs))
@@ -406,7 +407,7 @@ func TestSelectMemoriesUnderLimit(t *testing.T) {
 
 func TestBuildMessagesWithCustomPrompt(t *testing.T) {
 	custom := "You are a pirate assistant."
-	msgs := buildMessages(nil, nil, "hello", custom, "", false)
+	msgs := buildMessages(nil, nil, "hello", custom, "", "")
 
 	if len(msgs) != 2 {
 		t.Fatalf("expected 2 messages, got %d", len(msgs))
@@ -417,7 +418,7 @@ func TestBuildMessagesWithCustomPrompt(t *testing.T) {
 }
 
 func TestBuildMessagesWithoutMemories(t *testing.T) {
-	msgs := buildMessages(nil, nil, "hello", "", "", false)
+	msgs := buildMessages(nil, nil, "hello", "", "", "")
 
 	if len(msgs) != 2 {
 		t.Fatalf("expected 2 messages, got %d", len(msgs))
@@ -784,7 +785,7 @@ func TestSummaryInContext(t *testing.T) {
 }
 
 func TestBuildMessagesWithSummary(t *testing.T) {
-	msgs := buildMessages(nil, nil, "hello", "", "User likes Go.", false)
+	msgs := buildMessages(nil, nil, "hello", "", "User likes Go.", "")
 
 	if len(msgs) != 2 {
 		t.Fatalf("expected 2 messages, got %d", len(msgs))
@@ -1091,73 +1092,16 @@ func TestConversationsClearCommand(t *testing.T) {
 	}
 }
 
-func TestParseImageToolCall(t *testing.T) {
-	tests := []struct {
-		name      string
-		response  string
-		wantOK    bool
-		wantPrompt string
-	}{
-		{
-			name: "valid tool call",
-			response: `<tool_use>
-<name>generate_image</name>
-<parameters>
-<prompt>a cute orange cat sitting on a windowsill</prompt>
-</parameters>
-</tool_use>`,
-			wantOK:     true,
-			wantPrompt: "a cute orange cat sitting on a windowsill",
-		},
-		{
-			name:     "no tool call",
-			response: "Here is a description of a cat.",
-			wantOK:   false,
-		},
-		{
-			name: "different tool name",
-			response: `<tool_use>
-<name>other_tool</name>
-<parameters>
-<prompt>something</prompt>
-</parameters>
-</tool_use>`,
-			wantOK: false,
-		},
-		{
-			name: "empty prompt",
-			response: `<tool_use>
-<name>generate_image</name>
-<parameters>
-<prompt>  </prompt>
-</parameters>
-</tool_use>`,
-			wantOK: false,
-		},
+func TestBuildMessagesWithToolPrompt(t *testing.T) {
+	fragment := "\n\nYou have access to tools..."
+	msgs := buildMessages(nil, nil, "draw a cat", "", "", fragment)
+	if !strings.Contains(msgs[0].Content, "You have access to tools...") {
+		t.Error("expected tool prompt in system prompt when toolPrompt is non-empty")
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			prompt, ok := parseImageToolCall(tt.response)
-			if ok != tt.wantOK {
-				t.Errorf("parseImageToolCall() ok = %v, want %v", ok, tt.wantOK)
-			}
-			if ok && prompt != tt.wantPrompt {
-				t.Errorf("parseImageToolCall() prompt = %q, want %q", prompt, tt.wantPrompt)
-			}
-		})
-	}
-}
-
-func TestBuildMessagesWithImageGen(t *testing.T) {
-	msgs := buildMessages(nil, nil, "draw a cat", "", "", true)
-	if !strings.Contains(msgs[0].Content, "generate_image") {
-		t.Error("expected generate_image tool in system prompt when hasImageGen is true")
-	}
-
-	msgs = buildMessages(nil, nil, "draw a cat", "", "", false)
-	if strings.Contains(msgs[0].Content, "generate_image") {
-		t.Error("expected no generate_image tool in system prompt when hasImageGen is false")
+	msgs = buildMessages(nil, nil, "draw a cat", "", "", "")
+	if strings.Contains(msgs[0].Content, "You have access to tools...") {
+		t.Error("expected no tool prompt in system prompt when toolPrompt is empty")
 	}
 }
 
@@ -1182,7 +1126,10 @@ func TestHandleImageGeneration(t *testing.T) {
 	}
 	t.Cleanup(func() { db.Close() })
 
-	// Provider returns a tool call.
+	reg := tool.NewRegistry()
+	reg.Register(tool.NewImageTool(imgProvider))
+
+	// Provider returns a tool call on first call, then extraction response.
 	toolResponse := `<tool_use>
 <name>generate_image</name>
 <parameters>
@@ -1190,7 +1137,7 @@ func TestHandleImageGeneration(t *testing.T) {
 </parameters>
 </tool_use>`
 	mock := &mockProvider{name: "test", response: toolResponse}
-	l := NewLoop(h, mock, db, 50, 8000, 0, false, false, "", nil, imgProvider, nil)
+	l := NewLoop(h, mock, db, 50, 8000, 0, false, false, "", nil, reg, nil)
 
 	l.handle(context.Background(), hub.InMessage{ChatID: 1, Text: "draw a cat"})
 
@@ -1223,6 +1170,9 @@ func TestHandleImageGenerationError(t *testing.T) {
 	}
 	t.Cleanup(func() { db.Close() })
 
+	reg := tool.NewRegistry()
+	reg.Register(tool.NewImageTool(imgProvider))
+
 	toolResponse := `<tool_use>
 <name>generate_image</name>
 <parameters>
@@ -1230,7 +1180,7 @@ func TestHandleImageGenerationError(t *testing.T) {
 </parameters>
 </tool_use>`
 	mock := &mockProvider{name: "test", response: toolResponse}
-	l := NewLoop(h, mock, db, 50, 8000, 0, false, false, "", nil, imgProvider, nil)
+	l := NewLoop(h, mock, db, 50, 8000, 0, false, false, "", nil, reg, nil)
 
 	l.handle(context.Background(), hub.InMessage{ChatID: 1, Text: "draw something"})
 
@@ -1247,7 +1197,7 @@ func TestHandleImageGenerationError(t *testing.T) {
 	}
 }
 
-func TestNoImageProviderSkipsToolCall(t *testing.T) {
+func TestNoToolsSkipsToolCall(t *testing.T) {
 	toolResponse := `<tool_use>
 <name>generate_image</name>
 <parameters>
@@ -1255,12 +1205,12 @@ func TestNoImageProviderSkipsToolCall(t *testing.T) {
 </parameters>
 </tool_use>`
 	mock := &mockProvider{name: "test", response: toolResponse}
-	// No image provider (nil).
+	// No registry (nil) — no tools registered.
 	l, h, _ := testLoop(t, mock)
 
 	l.handle(context.Background(), hub.InMessage{ChatID: 1, Text: "draw a cat"})
 
-	// Without image provider, tool call is treated as normal text response.
+	// Without tools, tool call XML is treated as normal text response.
 	out := readOut(t, h)
 	if out.Text != toolResponse {
 		t.Errorf("expected raw tool response forwarded, got %q", out.Text)
@@ -1317,6 +1267,9 @@ func TestStreamingImageToolCallDeletesStreamedMessage(t *testing.T) {
 	}
 	t.Cleanup(func() { db.Close() })
 
+	reg := tool.NewRegistry()
+	reg.Register(tool.NewImageTool(imgProvider))
+
 	toolResponse := `<tool_use>
 <name>generate_image</name>
 <parameters>
@@ -1326,7 +1279,7 @@ func TestStreamingImageToolCallDeletesStreamedMessage(t *testing.T) {
 
 	sp := &mockStreamingProvider{mockProvider{name: "test", response: toolResponse}}
 	fb := provider.NewFallback([]provider.LLMProvider{sp}, 1, nil)
-	l := NewLoop(h, fb, db, 50, 8000, 0, false, true, "", nil, imgProvider, nil)
+	l := NewLoop(h, fb, db, 50, 8000, 0, false, true, "", nil, reg, nil)
 
 	// Use a trivial message (< 10 chars) so background memory extraction
 	// does not run and set sp.called via extProvider.Chat().
@@ -1370,5 +1323,78 @@ func TestStreamingImageToolCallDeletesStreamedMessage(t *testing.T) {
 	// Buffered Chat should NOT have been called (streaming succeeded).
 	if sp.called {
 		t.Error("buffered Chat should not be called when streaming succeeds")
+	}
+}
+
+// mockSearchTool implements tool.Tool for testing.
+type mockSearchTool struct {
+	result *tool.Result
+	err    error
+}
+
+func (m *mockSearchTool) Name() string        { return "search" }
+func (m *mockSearchTool) Description() string  { return "Search for information." }
+func (m *mockSearchTool) Parameters() []tool.Parameter {
+	return []tool.Parameter{{Name: "query", Type: "string", Required: true}}
+}
+func (m *mockSearchTool) Execute(_ context.Context, _ map[string]string) (*tool.Result, error) {
+	return m.result, m.err
+}
+
+func TestToolCallCycleTextResult(t *testing.T) {
+	// Provider returns a tool call first, then a text response after receiving result.
+	cap := &capturingProvider{responses: []string{
+		"<tool_use>\n<name>search</name>\n<parameters>\n<query>Go</query>\n</parameters>\n</tool_use>",
+		"Found results about Go.",
+		"[]",
+	}}
+
+	h := hub.New()
+	db, err := store.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	reg := tool.NewRegistry()
+	reg.Register(&mockSearchTool{result: &tool.Result{Text: "Go is a programming language."}})
+
+	l := NewLoop(h, cap, db, 50, 8000, 0, false, false, "", nil, reg, nil)
+	l.extProvider = cap
+
+	l.handle(context.Background(), hub.InMessage{ChatID: 1, Text: "search for Go info"})
+	out := readOut(t, h)
+	l.Wait()
+
+	if out.Text != "Found results about Go." {
+		t.Errorf("expected final response, got %q", out.Text)
+	}
+}
+
+func TestToolCallMaxLimit(t *testing.T) {
+	toolResponse := "<tool_use>\n<name>search</name>\n<parameters>\n<query>Go</query>\n</parameters>\n</tool_use>"
+	sp := &sequentialProvider{
+		responses: []string{toolResponse, toolResponse, toolResponse, "Final answer after limit.", "[]"},
+	}
+
+	h := hub.New()
+	db, err := store.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	reg := tool.NewRegistry()
+	reg.Register(&mockSearchTool{result: &tool.Result{Text: "result"}})
+
+	l := NewLoop(h, sp, db, 50, 8000, 0, false, false, "", nil, reg, nil)
+	l.extProvider = sp
+
+	l.handle(context.Background(), hub.InMessage{ChatID: 1, Text: "search repeatedly please"})
+	out := readOut(t, h)
+	l.Wait()
+
+	if out.Text != "Final answer after limit." {
+		t.Errorf("expected final answer after limit, got %q", out.Text)
 	}
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -30,22 +30,38 @@ type Metrics struct {
 	providerErrors     map[string]int64
 	providerLatencyMs  map[string]int64 // total latency in ms
 	providerLatencyCnt map[string]int64 // number of latency observations
+
+	// Per-tool counters.
+	toolCalls      map[string]int64
+	toolErrors     map[string]int64
+	toolLatencyMs  map[string]int64 // total latency in ms
+	toolLatencyCnt map[string]int64 // number of latency observations
 }
 
-// New creates a Metrics instance with per-provider maps pre-initialized.
-func New(providerNames []string) *Metrics {
+// New creates a Metrics instance with per-provider and per-tool maps pre-initialized.
+func New(providerNames, toolNames []string) *Metrics {
 	m := &Metrics{
 		startedAt:          time.Now(),
 		providerCalls:      make(map[string]int64, len(providerNames)),
 		providerErrors:     make(map[string]int64, len(providerNames)),
 		providerLatencyMs:  make(map[string]int64, len(providerNames)),
 		providerLatencyCnt: make(map[string]int64, len(providerNames)),
+		toolCalls:          make(map[string]int64, len(toolNames)),
+		toolErrors:         make(map[string]int64, len(toolNames)),
+		toolLatencyMs:      make(map[string]int64, len(toolNames)),
+		toolLatencyCnt:     make(map[string]int64, len(toolNames)),
 	}
 	for _, name := range providerNames {
 		m.providerCalls[name] = 0
 		m.providerErrors[name] = 0
 		m.providerLatencyMs[name] = 0
 		m.providerLatencyCnt[name] = 0
+	}
+	for _, name := range toolNames {
+		m.toolCalls[name] = 0
+		m.toolErrors[name] = 0
+		m.toolLatencyMs[name] = 0
+		m.toolLatencyCnt[name] = 0
 	}
 	return m
 }
@@ -94,6 +110,29 @@ func (m *Metrics) ObserveLatency(name string, d time.Duration) {
 	m.mu.Unlock()
 }
 
+// IncToolCall increments the tool_calls counter for the named tool.
+func (m *Metrics) IncToolCall(name string) {
+	m.mu.Lock()
+	m.toolCalls[name]++
+	m.mu.Unlock()
+}
+
+// IncToolError increments the tool_errors counter for the named tool.
+func (m *Metrics) IncToolError(name string) {
+	m.mu.Lock()
+	m.toolErrors[name]++
+	m.mu.Unlock()
+}
+
+// ObserveToolLatency records a tool call duration for the named tool.
+func (m *Metrics) ObserveToolLatency(name string, d time.Duration) {
+	ms := d.Milliseconds()
+	m.mu.Lock()
+	m.toolLatencyMs[name] += ms
+	m.toolLatencyCnt[name]++
+	m.mu.Unlock()
+}
+
 // IncExtractionSuccess increments the memory_extraction_successes counter.
 func (m *Metrics) IncExtractionSuccess() {
 	m.mu.Lock()
@@ -129,6 +168,22 @@ func (m *Metrics) Snapshot() map[string]any {
 	for k, v := range m.providerLatencyCnt {
 		providerLatencyCnt[k] = v
 	}
+	toolCalls := make(map[string]int64, len(m.toolCalls))
+	for k, v := range m.toolCalls {
+		toolCalls[k] = v
+	}
+	toolErrors := make(map[string]int64, len(m.toolErrors))
+	for k, v := range m.toolErrors {
+		toolErrors[k] = v
+	}
+	toolLatencyMs := make(map[string]int64, len(m.toolLatencyMs))
+	for k, v := range m.toolLatencyMs {
+		toolLatencyMs[k] = v
+	}
+	toolLatencyCnt := make(map[string]int64, len(m.toolLatencyCnt))
+	for k, v := range m.toolLatencyCnt {
+		toolLatencyCnt[k] = v
+	}
 
 	return map[string]any{
 		"started_at":                  m.startedAt.UTC().Format(time.RFC3339),
@@ -142,6 +197,10 @@ func (m *Metrics) Snapshot() map[string]any {
 		"provider_latency_ms_count":   providerLatencyCnt,
 		"memory_extraction_successes":  m.memoryExtractions,
 		"memory_extraction_failures":  m.memoryExtractionFailures,
+		"tool_calls":                  toolCalls,
+		"tool_errors":                 toolErrors,
+		"tool_latency_ms_total":       toolLatencyMs,
+		"tool_latency_ms_count":       toolLatencyCnt,
 	}
 }
 
@@ -160,6 +219,10 @@ func (m *Metrics) LogSummary() {
 		slog.Any("provider_latency_ms_count", snap["provider_latency_ms_count"]),
 		slog.Any("memory_extraction_successes", snap["memory_extraction_successes"]),
 		slog.Any("memory_extraction_failures", snap["memory_extraction_failures"]),
+		slog.Any("tool_calls", snap["tool_calls"]),
+		slog.Any("tool_errors", snap["tool_errors"]),
+		slog.Any("tool_latency_ms_total", snap["tool_latency_ms_total"]),
+		slog.Any("tool_latency_ms_count", snap["tool_latency_ms_count"]),
 	)
 }
 

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestIncrement(t *testing.T) {
-	m := New([]string{"claude", "chutes"})
+	m := New([]string{"claude", "chutes"}, nil)
 
 	m.IncReceived()
 	m.IncReceived()
@@ -73,7 +73,7 @@ func TestIncrement(t *testing.T) {
 }
 
 func TestSnapshotContainsUptime(t *testing.T) {
-	m := New(nil)
+	m := New(nil, nil)
 	snap := m.Snapshot()
 
 	if _, ok := snap["started_at"]; !ok {
@@ -85,7 +85,7 @@ func TestSnapshotContainsUptime(t *testing.T) {
 }
 
 func TestSnapshotIsolation(t *testing.T) {
-	m := New([]string{"p1"})
+	m := New([]string{"p1"}, nil)
 	m.IncProviderCall("p1")
 
 	snap := m.Snapshot()
@@ -100,7 +100,7 @@ func TestSnapshotIsolation(t *testing.T) {
 }
 
 func TestConcurrentIncrements(t *testing.T) {
-	m := New([]string{"p1"})
+	m := New([]string{"p1"}, nil)
 
 	var wg sync.WaitGroup
 	for i := 0; i < 100; i++ {
@@ -133,7 +133,7 @@ func TestConcurrentIncrements(t *testing.T) {
 }
 
 func TestHandler(t *testing.T) {
-	m := New([]string{"claude"})
+	m := New([]string{"claude"}, nil)
 	m.IncReceived()
 	m.IncProviderCall("claude")
 
@@ -152,5 +152,31 @@ func TestHandler(t *testing.T) {
 
 	if got := result["messages_received"].(float64); got != 1 {
 		t.Errorf("messages_received = %v, want 1", got)
+	}
+}
+
+func TestToolMetrics(t *testing.T) {
+	m := New([]string{"claude"}, []string{"generate_image"})
+
+	m.IncToolCall("generate_image")
+	m.IncToolCall("generate_image")
+	m.IncToolError("generate_image")
+	m.ObserveToolLatency("generate_image", 500*time.Millisecond)
+
+	snap := m.Snapshot()
+
+	toolCalls := snap["tool_calls"].(map[string]int64)
+	if got := toolCalls["generate_image"]; got != 2 {
+		t.Errorf("tool_calls[generate_image] = %d, want 2", got)
+	}
+
+	toolErrors := snap["tool_errors"].(map[string]int64)
+	if got := toolErrors["generate_image"]; got != 1 {
+		t.Errorf("tool_errors[generate_image] = %d, want 1", got)
+	}
+
+	toolLatTotal := snap["tool_latency_ms_total"].(map[string]int64)
+	if got := toolLatTotal["generate_image"]; got != 500 {
+		t.Errorf("tool_latency_ms_total[generate_image] = %d, want 500", got)
 	}
 }

--- a/internal/provider/openai.go
+++ b/internal/provider/openai.go
@@ -218,8 +218,9 @@ type openaiRequest struct {
 }
 
 type openaiMessage struct {
-	Role    string `json:"role"`
-	Content any    `json:"content"`
+	Role       string `json:"role"`
+	Content    any    `json:"content"`
+	ToolCallID string `json:"tool_call_id,omitempty"`
 }
 
 // buildOpenAIContent returns a plain string for text-only messages,
@@ -253,6 +254,163 @@ type openaiResponse struct {
 
 type openaiChoice struct {
 	Message openaiMessage `json:"message"`
+}
+
+// ChatWithTools sends a conversation with tool definitions to the OpenAI-compatible
+// endpoint. If the model responds with tool calls, they are returned in
+// ChatResponse.ToolCalls. Otherwise, the text reply is in ChatResponse.Text.
+func (o *OpenAI) ChatWithTools(ctx context.Context, messages []Message, opts ChatOptions) (*ChatResponse, error) {
+	reqBody := openaiToolRequest{
+		Model:    o.model,
+		Messages: make([]openaiMessage, len(messages)),
+	}
+	for i, m := range messages {
+		msg := openaiMessage{
+			Role:    m.Role,
+			Content: buildOpenAIContent(m),
+		}
+		if m.Role == "tool" && len(m.ToolResults) > 0 {
+			msg.ToolCallID = m.ToolResults[0].CallID
+			msg.Content = m.ToolResults[0].Result
+		}
+		reqBody.Messages[i] = msg
+	}
+	for _, td := range opts.Tools {
+		props := make(map[string]map[string]string, len(td.Parameters))
+		required := make([]string, 0)
+		for _, p := range td.Parameters {
+			props[p.Name] = map[string]string{
+				"type":        p.Type,
+				"description": p.Description,
+			}
+			if p.Required {
+				required = append(required, p.Name)
+			}
+		}
+		reqBody.Tools = append(reqBody.Tools, openaiTool{
+			Type: "function",
+			Function: openaiFunction{
+				Name:        td.Name,
+				Description: td.Description,
+				Parameters: openaiParameters{
+					Type:       "object",
+					Properties: props,
+					Required:   required,
+				},
+			},
+		})
+	}
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	url := o.baseURL + "/chat/completions"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+o.apiKey)
+
+	resp, err := o.client.Do(req)
+	if err != nil {
+		if isTimeoutError(ctx, err) {
+			return nil, fmt.Errorf("send request: %w: %w", ErrTimeout, err)
+		}
+		return nil, fmt.Errorf("send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize+1))
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+	if len(respBody) > maxResponseSize {
+		return nil, fmt.Errorf("response body exceeds %d bytes limit", maxResponseSize)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+			return nil, fmt.Errorf("API error (status %d): %s: %w", resp.StatusCode, respBody, ErrAuthFailure)
+		}
+		return nil, &HTTPStatusError{Code: resp.StatusCode, Body: string(respBody)}
+	}
+
+	var result openaiToolResponse
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+	if len(result.Choices) == 0 {
+		return nil, fmt.Errorf("empty response from %s", o.name)
+	}
+
+	msg := result.Choices[0].Message
+	if len(msg.ToolCalls) > 0 {
+		calls := make([]ToolCall, len(msg.ToolCalls))
+		for i, tc := range msg.ToolCalls {
+			var args map[string]string
+			if err := json.Unmarshal([]byte(tc.Function.Arguments), &args); err != nil {
+				return nil, fmt.Errorf("parse tool call arguments: %w", err)
+			}
+			calls[i] = ToolCall{
+				ID:   tc.ID,
+				Name: tc.Function.Name,
+				Args: args,
+			}
+		}
+		return &ChatResponse{ToolCalls: calls}, nil
+	}
+
+	text, _ := msg.Content.(string)
+	return &ChatResponse{Text: text}, nil
+}
+
+type openaiToolRequest struct {
+	Model    string          `json:"model"`
+	Messages []openaiMessage `json:"messages"`
+	Tools    []openaiTool    `json:"tools,omitempty"`
+}
+
+type openaiTool struct {
+	Type     string         `json:"type"`
+	Function openaiFunction `json:"function"`
+}
+
+type openaiFunction struct {
+	Name        string           `json:"name"`
+	Description string           `json:"description"`
+	Parameters  openaiParameters `json:"parameters"`
+}
+
+type openaiParameters struct {
+	Type       string                       `json:"type"`
+	Properties map[string]map[string]string `json:"properties"`
+	Required   []string                     `json:"required,omitempty"`
+}
+
+type openaiToolResponse struct {
+	Choices []openaiToolChoice `json:"choices"`
+}
+
+type openaiToolChoice struct {
+	Message openaiToolMessage `json:"message"`
+}
+
+type openaiToolMessage struct {
+	Role      string             `json:"role"`
+	Content   any                `json:"content"`
+	ToolCalls []openaiToolCallIn `json:"tool_calls,omitempty"`
+}
+
+type openaiToolCallIn struct {
+	ID       string `json:"id"`
+	Type     string `json:"type"`
+	Function struct {
+		Name      string `json:"name"`
+		Arguments string `json:"arguments"`
+	} `json:"function"`
 }
 
 // isTimeoutError returns true if the error indicates a timeout, either from

--- a/internal/provider/openai_test.go
+++ b/internal/provider/openai_test.go
@@ -235,6 +235,119 @@ func TestBuildOpenAIContentWithImage(t *testing.T) {
 	}
 }
 
+func TestOpenAIChatWithToolsTextResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req map[string]any
+		json.NewDecoder(r.Body).Decode(&req)
+
+		// Verify tools were sent.
+		tools, ok := req["tools"].([]any)
+		if !ok || len(tools) != 1 {
+			t.Errorf("expected 1 tool, got %v", req["tools"])
+		}
+
+		json.NewEncoder(w).Encode(map[string]any{
+			"choices": []map[string]any{
+				{"message": map[string]any{
+					"role":    "assistant",
+					"content": "Here is your answer.",
+				}},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	p := NewOpenAI("test", srv.URL, "model", "key")
+	resp, err := p.ChatWithTools(context.Background(), []Message{
+		{Role: "user", Content: "hello"},
+	}, ChatOptions{
+		Tools: []ToolDefinition{
+			{Name: "test_tool", Description: "A test", Parameters: []ToolParameter{
+				{Name: "arg", Type: "string", Description: "An arg", Required: true},
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ChatWithTools() error: %v", err)
+	}
+	if resp.Text != "Here is your answer." {
+		t.Errorf("Text = %q, want %q", resp.Text, "Here is your answer.")
+	}
+	if len(resp.ToolCalls) != 0 {
+		t.Errorf("expected no tool calls, got %d", len(resp.ToolCalls))
+	}
+}
+
+func TestOpenAIChatWithToolsToolCall(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"choices": []map[string]any{
+				{"message": map[string]any{
+					"role":    "assistant",
+					"content": nil,
+					"tool_calls": []map[string]any{
+						{
+							"id":   "call_123",
+							"type": "function",
+							"function": map[string]any{
+								"name":      "generate_image",
+								"arguments": `{"prompt":"a cute cat"}`,
+							},
+						},
+					},
+				}},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	p := NewOpenAI("test", srv.URL, "model", "key")
+	resp, err := p.ChatWithTools(context.Background(), []Message{
+		{Role: "user", Content: "draw a cat"},
+	}, ChatOptions{
+		Tools: []ToolDefinition{
+			{Name: "generate_image", Description: "Generate image", Parameters: []ToolParameter{
+				{Name: "prompt", Type: "string", Description: "Prompt", Required: true},
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ChatWithTools() error: %v", err)
+	}
+	if resp.Text != "" {
+		t.Errorf("Text = %q, want empty", resp.Text)
+	}
+	if len(resp.ToolCalls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(resp.ToolCalls))
+	}
+	tc := resp.ToolCalls[0]
+	if tc.ID != "call_123" {
+		t.Errorf("ID = %q, want %q", tc.ID, "call_123")
+	}
+	if tc.Name != "generate_image" {
+		t.Errorf("Name = %q, want %q", tc.Name, "generate_image")
+	}
+	if tc.Args["prompt"] != "a cute cat" {
+		t.Errorf("Args[prompt] = %q, want %q", tc.Args["prompt"], "a cute cat")
+	}
+}
+
+func TestOpenAIChatWithToolsAPIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("server error"))
+	}))
+	defer srv.Close()
+
+	p := NewOpenAI("test", srv.URL, "model", "key")
+	_, err := p.ChatWithTools(context.Background(), []Message{
+		{Role: "user", Content: "hello"},
+	}, ChatOptions{})
+	if err == nil {
+		t.Fatal("expected error for 500 response")
+	}
+}
+
 func TestOpenAIChatWithImage(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var raw map[string]any

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -34,10 +34,11 @@ type ImageData struct {
 
 // Message represents a single message in a conversation.
 type Message struct {
-	Role      string      `json:"role"`    // "user", "assistant", "system"
-	Content   string      `json:"content"`
-	Images    []ImageData `json:"images,omitempty"`
-	Timestamp time.Time   `json:"timestamp"`
+	Role        string       `json:"role"`    // "user", "assistant", "system"
+	Content     string       `json:"content"`
+	Images      []ImageData  `json:"images,omitempty"`
+	ToolResults []ToolResult `json:"tool_results,omitempty"`
+	Timestamp   time.Time    `json:"timestamp"`
 }
 
 // LLMProvider is the interface that all LLM backends must implement.
@@ -56,4 +57,51 @@ type StreamingProvider interface {
 	// Providers must check ctx.Done() between processing each event/line to allow
 	// prompt cancellation. Returns the complete response string on success.
 	ChatStream(ctx context.Context, messages []Message, fn func(delta string)) (string, error)
+}
+
+// ChatOptions configures a tool-aware chat call.
+type ChatOptions struct {
+	Tools []ToolDefinition
+}
+
+// ToolDefinition describes a tool for providers with native function calling.
+type ToolDefinition struct {
+	Name        string
+	Description string
+	Parameters  []ToolParameter
+}
+
+// ToolParameter describes a single tool parameter.
+type ToolParameter struct {
+	Name        string
+	Type        string
+	Description string
+	Required    bool
+}
+
+// ChatResponse is the result of a tool-aware chat call.
+type ChatResponse struct {
+	Text      string     // final text response (empty if tool calls present)
+	ToolCalls []ToolCall // tool invocations requested by the LLM
+}
+
+// ToolCall represents a tool invocation from the LLM.
+type ToolCall struct {
+	ID   string            // provider-assigned call ID (OpenAI requires for result pairing)
+	Name string
+	Args map[string]string
+}
+
+// ToolResult feeds a tool execution result back to the provider.
+type ToolResult struct {
+	CallID string // matches ToolCall.ID
+	Result string
+}
+
+// ToolProvider is an optional interface for providers that support native
+// function calling. Providers that don't implement this get tool support
+// via XML prompt injection (PromptCaller).
+type ToolProvider interface {
+	LLMProvider
+	ChatWithTools(ctx context.Context, messages []Message, opts ChatOptions) (*ChatResponse, error)
 }

--- a/internal/tool/image.go
+++ b/internal/tool/image.go
@@ -1,0 +1,62 @@
+package tool
+
+import (
+	"context"
+	"fmt"
+)
+
+// ImageProvider generates images from text prompts. This mirrors
+// provider.ImageProvider to avoid a circular import.
+type ImageProvider interface {
+	Name() string
+	Generate(ctx context.Context, prompt string) ([]byte, error)
+}
+
+// ImageTool wraps an ImageProvider as a Tool.
+type ImageTool struct {
+	provider ImageProvider
+}
+
+// NewImageTool creates a Tool that generates images via the given provider.
+func NewImageTool(p ImageProvider) *ImageTool {
+	return &ImageTool{provider: p}
+}
+
+// Name returns "generate_image".
+func (t *ImageTool) Name() string { return "generate_image" }
+
+// Description returns a description for the LLM.
+func (t *ImageTool) Description() string {
+	return "Generate an image from a text description. Use this when the user asks you to draw, create, generate, or make an image or picture."
+}
+
+// Parameters returns the tool's parameter definitions.
+func (t *ImageTool) Parameters() []Parameter {
+	return []Parameter{
+		{
+			Name:        "prompt",
+			Type:        "string",
+			Description: "A detailed description of the image to generate.",
+			Required:    true,
+		},
+	}
+}
+
+// Execute generates an image from the prompt argument. Returns the image bytes
+// in Result.Data and a confirmation message in Result.Text.
+func (t *ImageTool) Execute(ctx context.Context, args map[string]string) (*Result, error) {
+	prompt := args["prompt"]
+	if prompt == "" {
+		return nil, fmt.Errorf("missing required parameter: prompt")
+	}
+
+	data, err := t.provider.Generate(ctx, prompt)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Result{
+		Text: "Image generated successfully.",
+		Data: data,
+	}, nil
+}

--- a/internal/tool/image_test.go
+++ b/internal/tool/image_test.go
@@ -1,0 +1,81 @@
+package tool
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+// mockImageProvider implements ImageProvider for testing.
+type mockImageProvider struct {
+	name string
+	data []byte
+	err  error
+}
+
+func (m *mockImageProvider) Name() string { return m.name }
+func (m *mockImageProvider) Generate(_ context.Context, _ string) ([]byte, error) {
+	return m.data, m.err
+}
+
+func TestImageToolName(t *testing.T) {
+	it := NewImageTool(&mockImageProvider{name: "test"})
+	if got := it.Name(); got != "generate_image" {
+		t.Errorf("Name() = %q, want %q", got, "generate_image")
+	}
+}
+
+func TestImageToolDescription(t *testing.T) {
+	it := NewImageTool(&mockImageProvider{name: "test"})
+	if got := it.Description(); got == "" {
+		t.Error("Description() returned empty string")
+	}
+}
+
+func TestImageToolParameters(t *testing.T) {
+	it := NewImageTool(&mockImageProvider{name: "test"})
+	params := it.Parameters()
+	if len(params) != 1 {
+		t.Fatalf("expected 1 parameter, got %d", len(params))
+	}
+	if params[0].Name != "prompt" {
+		t.Errorf("parameter name = %q, want %q", params[0].Name, "prompt")
+	}
+	if !params[0].Required {
+		t.Error("prompt parameter should be required")
+	}
+}
+
+func TestImageToolExecuteSuccess(t *testing.T) {
+	imgData := []byte("fake-png-data")
+	it := NewImageTool(&mockImageProvider{name: "test", data: imgData})
+
+	result, err := it.Execute(context.Background(), map[string]string{"prompt": "a cat"})
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+	if string(result.Data) != string(imgData) {
+		t.Errorf("Data = %q, want %q", result.Data, imgData)
+	}
+	if result.Text == "" {
+		t.Error("Text should be non-empty on success")
+	}
+}
+
+func TestImageToolExecuteError(t *testing.T) {
+	it := NewImageTool(&mockImageProvider{name: "test", err: fmt.Errorf("generation failed")})
+
+	_, err := it.Execute(context.Background(), map[string]string{"prompt": "a cat"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestImageToolExecuteMissingPrompt(t *testing.T) {
+	it := NewImageTool(&mockImageProvider{name: "test", data: []byte("data")})
+
+	_, err := it.Execute(context.Background(), map[string]string{})
+	if err == nil {
+		t.Fatal("expected error for missing prompt, got nil")
+	}
+}

--- a/internal/tool/prompt.go
+++ b/internal/tool/prompt.go
@@ -1,0 +1,88 @@
+package tool
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// PromptCaller handles tool calling for providers that don't support native
+// function calling. It injects tool definitions as XML into the system prompt
+// and parses XML tool call blocks from LLM responses.
+type PromptCaller struct {
+	registry *Registry
+}
+
+// NewPromptCaller creates a PromptCaller backed by the given registry.
+func NewPromptCaller(r *Registry) *PromptCaller {
+	return &PromptCaller{registry: r}
+}
+
+// PromptFragment returns the XML tool definitions block to append to the
+// system prompt. Returns "" if the registry has no tools.
+func (pc *PromptCaller) PromptFragment() string {
+	tools := pc.registry.All()
+	if len(tools) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("\n\nYou have access to the following tools:\n")
+
+	for _, t := range tools {
+		b.WriteString("\n<tool>\n")
+		fmt.Fprintf(&b, "<name>%s</name>\n", t.Name())
+		fmt.Fprintf(&b, "<description>%s</description>\n", t.Description())
+		params := t.Parameters()
+		if len(params) > 0 {
+			b.WriteString("<parameters>\n")
+			for _, p := range params {
+				req := "false"
+				if p.Required {
+					req = "true"
+				}
+				fmt.Fprintf(&b, "<parameter name=%q type=%q required=%q>%s</parameter>\n", p.Name, p.Type, req, p.Description)
+			}
+			b.WriteString("</parameters>\n")
+		}
+		b.WriteString("</tool>\n")
+	}
+
+	b.WriteString("\nWhen you want to use a tool, respond with this XML block:\n")
+	b.WriteString("<tool_use>\n<name>tool_name</name>\n<parameters>\n<param_name>value</param_name>\n</parameters>\n</tool_use>")
+
+	return b.String()
+}
+
+// toolUseRe matches a <tool_use> block and captures the name and parameters section.
+var toolUseRe = regexp.MustCompile(`(?s)<tool_use>\s*<name>(.*?)</name>\s*<parameters>(.*?)</parameters>\s*</tool_use>`)
+
+// paramRe matches individual parameter elements within a <parameters> block.
+// It captures the open tag name, content, and close tag name separately because
+// Go's RE2 engine does not support backreferences.
+var paramRe = regexp.MustCompile(`(?s)<(\w+)>(.*?)</(\w+)>`)
+
+// Parse extracts a tool call from an LLM text response. Returns nil if the
+// response contains no valid tool call for a registered tool.
+func (pc *PromptCaller) Parse(response string) *ToolCall {
+	matches := toolUseRe.FindStringSubmatch(response)
+	if len(matches) < 3 {
+		return nil
+	}
+
+	name := strings.TrimSpace(matches[1])
+	if _, ok := pc.registry.Get(name); !ok {
+		return nil
+	}
+
+	args := make(map[string]string)
+	paramMatches := paramRe.FindAllStringSubmatch(matches[2], -1)
+	for _, pm := range paramMatches {
+		// pm[1] = open tag name, pm[2] = content, pm[3] = close tag name
+		if len(pm) >= 4 && pm[1] == pm[3] {
+			args[pm[1]] = strings.TrimSpace(pm[2])
+		}
+	}
+
+	return &ToolCall{Name: name, Args: args}
+}

--- a/internal/tool/prompt_test.go
+++ b/internal/tool/prompt_test.go
@@ -1,0 +1,205 @@
+package tool
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPromptFragmentEmpty(t *testing.T) {
+	r := NewRegistry()
+	pc := NewPromptCaller(r)
+	if got := pc.PromptFragment(); got != "" {
+		t.Errorf("expected empty fragment for empty registry, got %q", got)
+	}
+}
+
+func TestPromptFragmentSingleTool(t *testing.T) {
+	r := NewRegistry()
+	r.Register(&mockTool{
+		name: "generate_image",
+		desc: "Generate an image from a text description.",
+		params: []Parameter{
+			{Name: "prompt", Type: "string", Description: "Image description.", Required: true},
+		},
+	})
+
+	pc := NewPromptCaller(r)
+	frag := pc.PromptFragment()
+
+	if !strings.Contains(frag, "<name>generate_image</name>") {
+		t.Errorf("expected tool name in fragment, got:\n%s", frag)
+	}
+	if !strings.Contains(frag, "<description>Generate an image from a text description.</description>") {
+		t.Errorf("expected description in fragment, got:\n%s", frag)
+	}
+	if !strings.Contains(frag, `<parameter name="prompt" type="string" required="true">Image description.</parameter>`) {
+		t.Errorf("expected parameter in fragment, got:\n%s", frag)
+	}
+	if !strings.Contains(frag, "<tool_use>") {
+		t.Errorf("expected usage instructions in fragment, got:\n%s", frag)
+	}
+}
+
+func TestPromptFragmentMultipleTools(t *testing.T) {
+	r := NewRegistry()
+	r.Register(&mockTool{name: "alpha", desc: "Tool A"})
+	r.Register(&mockTool{name: "bravo", desc: "Tool B"})
+
+	pc := NewPromptCaller(r)
+	frag := pc.PromptFragment()
+
+	alphaIdx := strings.Index(frag, "<name>alpha</name>")
+	bravoIdx := strings.Index(frag, "<name>bravo</name>")
+	if alphaIdx < 0 || bravoIdx < 0 {
+		t.Fatalf("expected both tools in fragment, got:\n%s", frag)
+	}
+	if alphaIdx > bravoIdx {
+		t.Error("expected tools in alphabetical order")
+	}
+}
+
+func TestParseValidToolCall(t *testing.T) {
+	r := NewRegistry()
+	r.Register(&mockTool{
+		name: "generate_image",
+		params: []Parameter{
+			{Name: "prompt", Type: "string"},
+		},
+	})
+	pc := NewPromptCaller(r)
+
+	response := `Sure, I'll generate that for you.
+<tool_use>
+<name>generate_image</name>
+<parameters>
+<prompt>a cute orange cat</prompt>
+</parameters>
+</tool_use>`
+
+	tc := pc.Parse(response)
+	if tc == nil {
+		t.Fatal("expected tool call, got nil")
+	}
+	if tc.Name != "generate_image" {
+		t.Errorf("Name = %q, want %q", tc.Name, "generate_image")
+	}
+	if tc.Args["prompt"] != "a cute orange cat" {
+		t.Errorf("Args[prompt] = %q, want %q", tc.Args["prompt"], "a cute orange cat")
+	}
+}
+
+func TestParseMultipleParameters(t *testing.T) {
+	r := NewRegistry()
+	r.Register(&mockTool{
+		name: "search",
+		params: []Parameter{
+			{Name: "query", Type: "string"},
+			{Name: "limit", Type: "number"},
+		},
+	})
+	pc := NewPromptCaller(r)
+
+	response := `<tool_use>
+<name>search</name>
+<parameters>
+<query>Go programming</query>
+<limit>5</limit>
+</parameters>
+</tool_use>`
+
+	tc := pc.Parse(response)
+	if tc == nil {
+		t.Fatal("expected tool call, got nil")
+	}
+	if tc.Args["query"] != "Go programming" {
+		t.Errorf("Args[query] = %q, want %q", tc.Args["query"], "Go programming")
+	}
+	if tc.Args["limit"] != "5" {
+		t.Errorf("Args[limit] = %q, want %q", tc.Args["limit"], "5")
+	}
+}
+
+func TestParseNoToolCall(t *testing.T) {
+	r := NewRegistry()
+	pc := NewPromptCaller(r)
+
+	tc := pc.Parse("Just a regular text response.")
+	if tc != nil {
+		t.Errorf("expected nil for non-tool response, got %+v", tc)
+	}
+}
+
+func TestParseUnknownTool(t *testing.T) {
+	r := NewRegistry()
+	pc := NewPromptCaller(r)
+
+	response := `<tool_use>
+<name>unknown_tool</name>
+<parameters>
+<arg>value</arg>
+</parameters>
+</tool_use>`
+
+	tc := pc.Parse(response)
+	if tc != nil {
+		t.Errorf("expected nil for unknown tool, got %+v", tc)
+	}
+}
+
+func TestParseEmptyParameters(t *testing.T) {
+	r := NewRegistry()
+	r.Register(&mockTool{name: "ping"})
+	pc := NewPromptCaller(r)
+
+	response := `<tool_use>
+<name>ping</name>
+<parameters>
+</parameters>
+</tool_use>`
+
+	tc := pc.Parse(response)
+	if tc == nil {
+		t.Fatal("expected tool call, got nil")
+	}
+	if tc.Name != "ping" {
+		t.Errorf("Name = %q, want %q", tc.Name, "ping")
+	}
+	if len(tc.Args) != 0 {
+		t.Errorf("expected empty args, got %v", tc.Args)
+	}
+}
+
+func TestRoundTrip(t *testing.T) {
+	r := NewRegistry()
+	r.Register(&mockTool{
+		name: "generate_image",
+		desc: "Generate an image.",
+		params: []Parameter{
+			{Name: "prompt", Type: "string", Description: "Image description.", Required: true},
+		},
+	})
+	pc := NewPromptCaller(r)
+
+	frag := pc.PromptFragment()
+	if !strings.Contains(frag, "<tool_use>") {
+		t.Fatal("fragment missing usage instructions")
+	}
+
+	response := `<tool_use>
+<name>generate_image</name>
+<parameters>
+<prompt>a sunset over mountains</prompt>
+</parameters>
+</tool_use>`
+
+	tc := pc.Parse(response)
+	if tc == nil {
+		t.Fatal("round-trip failed: Parse returned nil")
+	}
+	if tc.Name != "generate_image" {
+		t.Errorf("round-trip Name = %q, want %q", tc.Name, "generate_image")
+	}
+	if tc.Args["prompt"] != "a sunset over mountains" {
+		t.Errorf("round-trip Args[prompt] = %q, want %q", tc.Args["prompt"], "a sunset over mountains")
+	}
+}

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -1,0 +1,79 @@
+// Package tool defines the Tool interface and Registry used by the agent loop
+// to discover and invoke executable capabilities exposed to the LLM.
+package tool
+
+import (
+	"context"
+	"fmt"
+	"sort"
+)
+
+// Tool is an executable capability the LLM can invoke.
+type Tool interface {
+	// Name returns the tool's unique identifier.
+	Name() string
+	// Description returns a human-readable description for the LLM.
+	Description() string
+	// Parameters returns the tool's parameter definitions.
+	Parameters() []Parameter
+	// Execute runs the tool with the given arguments.
+	Execute(ctx context.Context, args map[string]string) (*Result, error)
+}
+
+// Parameter describes a single tool parameter.
+type Parameter struct {
+	Name        string
+	Type        string // "string", "number", "boolean"
+	Description string
+	Required    bool
+}
+
+// Result holds the output of a tool execution.
+type Result struct {
+	Text string // text result fed back to the LLM
+	Data []byte // binary data (e.g., image bytes) — routed by agent loop, not sent to LLM
+}
+
+// ToolCall represents a parsed tool invocation from an LLM response.
+type ToolCall struct {
+	Name string
+	Args map[string]string
+}
+
+// Registry holds registered tools and provides lookup.
+type Registry struct {
+	tools map[string]Tool
+}
+
+// NewRegistry creates an empty tool registry.
+func NewRegistry() *Registry {
+	return &Registry{tools: make(map[string]Tool)}
+}
+
+// Register adds a tool to the registry. Returns an error if a tool with the
+// same name is already registered.
+func (r *Registry) Register(t Tool) error {
+	if _, exists := r.tools[t.Name()]; exists {
+		return fmt.Errorf("tool %q already registered", t.Name())
+	}
+	r.tools[t.Name()] = t
+	return nil
+}
+
+// Get returns the tool with the given name, or false if not found.
+func (r *Registry) Get(name string) (Tool, bool) {
+	t, ok := r.tools[name]
+	return t, ok
+}
+
+// All returns all registered tools in alphabetical order.
+func (r *Registry) All() []Tool {
+	tools := make([]Tool, 0, len(r.tools))
+	for _, t := range r.tools {
+		tools = append(tools, t)
+	}
+	sort.Slice(tools, func(i, j int) bool {
+		return tools[i].Name() < tools[j].Name()
+	})
+	return tools
+}

--- a/internal/tool/tool_test.go
+++ b/internal/tool/tool_test.go
@@ -1,0 +1,81 @@
+package tool
+
+import (
+	"context"
+	"testing"
+)
+
+// mockTool implements Tool for testing.
+type mockTool struct {
+	name   string
+	desc   string
+	params []Parameter
+	result *Result
+	err    error
+}
+
+func (m *mockTool) Name() string                   { return m.name }
+func (m *mockTool) Description() string             { return m.desc }
+func (m *mockTool) Parameters() []Parameter         { return m.params }
+func (m *mockTool) Execute(_ context.Context, _ map[string]string) (*Result, error) {
+	return m.result, m.err
+}
+
+func TestRegistryRegisterAndGet(t *testing.T) {
+	r := NewRegistry()
+	tool := &mockTool{name: "test_tool", desc: "A test tool"}
+
+	if err := r.Register(tool); err != nil {
+		t.Fatalf("Register() error: %v", err)
+	}
+
+	got, ok := r.Get("test_tool")
+	if !ok {
+		t.Fatal("Get() returned false for registered tool")
+	}
+	if got.Name() != "test_tool" {
+		t.Errorf("Get() name = %q, want %q", got.Name(), "test_tool")
+	}
+}
+
+func TestRegistryGetMissing(t *testing.T) {
+	r := NewRegistry()
+	_, ok := r.Get("nonexistent")
+	if ok {
+		t.Error("Get() returned true for missing tool")
+	}
+}
+
+func TestRegistryDuplicateErrors(t *testing.T) {
+	r := NewRegistry()
+	tool := &mockTool{name: "dup"}
+	if err := r.Register(tool); err != nil {
+		t.Fatalf("first Register() error: %v", err)
+	}
+	if err := r.Register(tool); err == nil {
+		t.Error("expected error on duplicate Register()")
+	}
+}
+
+func TestRegistryAllStableOrder(t *testing.T) {
+	r := NewRegistry()
+	r.Register(&mockTool{name: "charlie"})
+	r.Register(&mockTool{name: "alpha"})
+	r.Register(&mockTool{name: "bravo"})
+
+	all := r.All()
+	if len(all) != 3 {
+		t.Fatalf("All() returned %d tools, want 3", len(all))
+	}
+	if all[0].Name() != "alpha" || all[1].Name() != "bravo" || all[2].Name() != "charlie" {
+		t.Errorf("All() not sorted: %s, %s, %s", all[0].Name(), all[1].Name(), all[2].Name())
+	}
+}
+
+func TestRegistryAllEmpty(t *testing.T) {
+	r := NewRegistry()
+	all := r.All()
+	if len(all) != 0 {
+		t.Errorf("All() returned %d tools for empty registry, want 0", len(all))
+	}
+}


### PR DESCRIPTION
## Summary

- New `internal/tool/` package with `Tool` interface, `Registry`, `PromptCaller` (XML-based tool calling), and `ImageTool` adapter
- `ToolProvider` interface and `ChatWithTools` on OpenAI provider for native function calling
- Agent loop `executeToolCalls` method replacing hardcoded image generation with a generic tool execution cycle (3-call limit, 90s per-tool timeout)
- Per-tool metrics (call counts, errors, latency) following the existing per-provider pattern
- `generate_image` migrated as the first registered tool, proving the framework end-to-end

## Test Plan

- [x] `go test -race ./...` — all packages pass, no races
- [x] `go vet ./...` — clean
- [x] `CGO_ENABLED=0 go build ./cmd/herald` — compiles
- [x] Existing image generation tests migrated to registry-based approach
- [x] New tests: tool cycle with text results, max tool call limit, PromptCaller XML round-trip, ImageTool adapter, OpenAI ChatWithTools
- [ ] Manual verification: send image generation request via Telegram

Closes #149

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>