### PR TITLE
feat(config): startup config validation and validate-config command

### DIFF
--- a/cmd/herald/main.go
+++ b/cmd/herald/main.go
@@ -81,19 +81,8 @@ func serve(configPath string) error {
 
 	initLogging(cfg.LogLevel)
 
-	// Log config validation results.
-	vr := cfg.Validate()
-	for _, w := range vr.Warnings {
-		slog.Warn(w)
-	}
-	for _, d := range vr.Defaults {
-		slog.Info(d)
-	}
-
 	if cfg.SystemPrompt == "" {
 		slog.Info("system_prompt not set, using default")
-	} else if len(cfg.SystemPrompt) > 4000 {
-		slog.Warn("system_prompt is very long, may consume significant context window", slog.Int("length", len(cfg.SystemPrompt)))
 	}
 
 	if cfg.Telegram.Token == "" {
@@ -113,6 +102,16 @@ func serve(configPath string) error {
 		return fmt.Errorf("no providers configured")
 	}
 	provider.ValidateProviders(context.Background(), providers)
+
+	// Log non-fatal config validation results (after fatal checks to avoid
+	// duplicate messaging for conditions that are already hard errors).
+	vr := cfg.Validate()
+	for _, w := range vr.Warnings {
+		slog.Warn(w)
+	}
+	for _, d := range vr.Defaults {
+		slog.Info(d)
+	}
 
 	providerNames := make([]string, len(providers))
 	for i, p := range providers {

--- a/cmd/herald/main.go
+++ b/cmd/herald/main.go
@@ -80,6 +80,15 @@ func serve(configPath string) error {
 
 	initLogging(cfg.LogLevel)
 
+	// Log config validation results.
+	vr := cfg.Validate()
+	for _, w := range vr.Warnings {
+		slog.Warn(w)
+	}
+	for _, d := range vr.Defaults {
+		slog.Info(d)
+	}
+
 	if cfg.SystemPrompt == "" {
 		slog.Info("system_prompt not set, using default")
 	} else if len(cfg.SystemPrompt) > 4000 {

--- a/cmd/herald/main.go
+++ b/cmd/herald/main.go
@@ -41,6 +41,7 @@ func main() {
 
 	root.PersistentFlags().StringVarP(&configPath, "config", "c", "config.json", "path to config file")
 	root.AddCommand(newAskCmd())
+	root.AddCommand(newValidateCmd())
 
 	if err := root.Execute(); err != nil {
 		os.Exit(1)

--- a/cmd/herald/validate.go
+++ b/cmd/herald/validate.go
@@ -34,6 +34,10 @@ func newValidateCmd() *cobra.Command {
 				fmt.Fprintln(os.Stderr, "config OK — no warnings, no defaults applied")
 			}
 
+			if len(result.Warnings) > 0 {
+				return fmt.Errorf("config has %d warning(s)", len(result.Warnings))
+			}
+
 			return nil
 		},
 	}

--- a/cmd/herald/validate.go
+++ b/cmd/herald/validate.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/sgraczyk/herald"
+	"github.com/sgraczyk/herald/internal/config"
+)
+
+func newValidateCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "validate-config",
+		Short: "Validate config file and report warnings",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			configPath, _ := cmd.Flags().GetString("config")
+
+			cfg, err := config.LoadWithDefaults(configPath, herald.DefaultConfig)
+			if err != nil {
+				return fmt.Errorf("load config: %w", err)
+			}
+
+			result := cfg.Validate()
+
+			for _, w := range result.Warnings {
+				fmt.Fprintf(os.Stderr, "WARNING: %s\n", w)
+			}
+			for _, d := range result.Defaults {
+				fmt.Fprintf(os.Stderr, "INFO: %s\n", d)
+			}
+
+			if len(result.Warnings) == 0 && len(result.Defaults) == 0 {
+				fmt.Fprintln(os.Stderr, "config OK — no warnings, no defaults applied")
+			}
+
+			return nil
+		},
+	}
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -245,6 +245,25 @@ Herald embeds `config.json.example` into the binary at build time via `//go:embe
 - **Reset to defaults:** Delete `config.json` and restart Herald.
 - **`--config` flag:** If the specified file doesn't exist, falls back to embedded defaults.
 
+## Validating Configuration
+
+Run `validate-config` to check a config file without starting the bot:
+
+```bash
+./herald validate-config
+./herald validate-config -c /etc/herald/config.json
+```
+
+Warnings (`WARNING:`) indicate settings that may prevent Herald from working correctly. Defaults (`INFO:`) report values Herald will supply automatically when a field is absent from the config file.
+
+Exit code is `1` when warnings are present, `0` otherwise. Suitable for CI or pre-deployment scripts:
+
+```bash
+./herald validate-config -c config.json && systemctl start herald
+```
+
+Herald also logs these same validation results at startup — warnings via `slog.Warn`, defaults via `slog.Info`. These do not block startup.
+
 ## Troubleshooting
 
 | Error | Cause | Fix |
@@ -259,6 +278,7 @@ Herald embeds `config.json.example` into the binary at build time via `//go:embe
 | `provider unreachable` | Network issue or API down | Wait for recovery; Herald retries per message |
 | `claude CLI not found on PATH` | Claude Code CLI not installed | Install Claude Code CLI (requires Node.js) |
 | `no providers configured` | Empty providers array | At least one provider must be in config |
+| `WARN` lines at startup | Config has missing or misconfigured fields | Run `herald validate-config` and address the reported fields |
 | Photos fail after update | Model lacks vision support | Confirm vision-capable model in config (look for `VL` suffix) |
 | Image generation times out | Chutes.ai slow or unreachable | Check network; 60s timeout is not configurable |
 | `API error (status 401)` from image provider | Invalid Chutes.ai API key | Update `CHUTES_API_KEY` in `.env`, restart |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,6 +29,9 @@ type Config struct {
 
 	// Raw field for env var resolution.
 	AllowedUserIDsEnv string `json:"allowed_user_ids_env"`
+
+	// presentKeys tracks which top-level JSON keys were explicitly set.
+	presentKeys map[string]bool `json:"-"`
 }
 
 // StatusMessages holds user-facing status and error message templates.
@@ -92,9 +95,20 @@ func LoadWithDefaults(path string, defaults []byte) (*Config, error) {
 		}
 	}
 
+	// Capture which top-level keys are present before unmarshalling
+	// into Config, so Validate can distinguish explicit values from defaults.
+	var rawKeys map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawKeys); err != nil {
+		return nil, fmt.Errorf("parse config file: %w", err)
+	}
+
 	var cfg Config
 	if err := json.Unmarshal(data, &cfg); err != nil {
 		return nil, fmt.Errorf("parse config file: %w", err)
+	}
+	cfg.presentKeys = make(map[string]bool, len(rawKeys))
+	for k := range rawKeys {
+		cfg.presentKeys[k] = true
 	}
 
 	if cfg.HistoryLimit == 0 {
@@ -217,6 +231,75 @@ func applyStatusMessageDefaults(cfg *Config) error {
 		}
 	}
 	return nil
+}
+
+// ValidationResult holds the output of config validation.
+type ValidationResult struct {
+	Warnings []string // feature-level issues, potential misconfigurations
+	Defaults []string // fields where defaults were applied
+}
+
+// Validate inspects the loaded config and returns warnings about missing
+// feature configuration and info about fields where defaults were applied.
+func (c *Config) Validate() ValidationResult {
+	var r ValidationResult
+
+	// --- Warnings ---
+
+	if len(c.Providers) == 0 {
+		r.Warnings = append(r.Warnings, "no providers configured — herald will not start")
+	}
+
+	if c.Telegram.Token == "" {
+		r.Warnings = append(r.Warnings,
+			fmt.Sprintf("telegram token not set (env var: %s) — herald will not start", c.Telegram.TokenEnv))
+	}
+
+	if len(c.ImageProviders) == 0 {
+		r.Warnings = append(r.Warnings,
+			"image_providers not configured — image generation will be unavailable")
+	}
+
+	for _, p := range c.Providers {
+		if p.Type == "openai" && p.APIKey == "" {
+			r.Warnings = append(r.Warnings,
+				fmt.Sprintf("provider %q: API key not set (env var: %s)", p.Name, p.APIKeyEnv))
+		}
+	}
+
+	if c.AllowedUserIDsEnv == "" {
+		if !c.presentKeys["allowed_user_ids_env"] {
+			r.Warnings = append(r.Warnings,
+				"allowed_user_ids_env not configured — no user whitelist set")
+		}
+	} else if len(c.AllowedUserIDs) == 0 {
+		r.Warnings = append(r.Warnings,
+			fmt.Sprintf("allowed user IDs env var %q is empty — all messages will be rejected",
+				c.AllowedUserIDsEnv))
+	}
+
+	// --- Defaults ---
+
+	type defaultField struct {
+		key   string
+		value any
+	}
+	fields := []defaultField{
+		{"history_limit", c.HistoryLimit},
+		{"history_token_budget", c.HistoryTokenBudget},
+		{"max_document_tokens", c.MaxDocumentTokens},
+		{"max_retries", *c.MaxRetries},
+		{"max_archived_conversations", *c.MaxArchivedConversations},
+		{"log_level", c.LogLevel},
+	}
+	for _, f := range fields {
+		if !c.presentKeys[f.key] {
+			r.Defaults = append(r.Defaults,
+				fmt.Sprintf("using default %s: %v", f.key, f.value))
+		}
+	}
+
+	return r
 }
 
 func parseUserIDs(raw string) ([]int64, error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -244,6 +244,10 @@ type ValidationResult struct {
 func (c *Config) Validate() ValidationResult {
 	var r ValidationResult
 
+	if c.presentKeys == nil {
+		c.presentKeys = make(map[string]bool)
+	}
+
 	// --- Warnings ---
 
 	if len(c.Providers) == 0 {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -190,7 +190,7 @@ func LoadWithDefaults(path string, defaults []byte) (*Config, error) {
 
 // applyStatusMessageDefaults fills in missing status message fields with
 // English defaults. If status_messages is nil, a fully-populated default
-// struct is created. If any explicitly-set field is empty, validation fails.
+// struct is created. Empty fields are replaced with their defaults.
 func applyStatusMessageDefaults(cfg *Config) error {
 	defaults := StatusMessages{
 		ImageGenerating: "Generating image...",
@@ -235,8 +235,10 @@ func applyStatusMessageDefaults(cfg *Config) error {
 
 // ValidationResult holds the output of config validation.
 type ValidationResult struct {
-	Warnings []string // feature-level issues, potential misconfigurations
-	Defaults []string // fields where defaults were applied
+	// Warnings lists feature-level issues and potential misconfigurations.
+	Warnings []string
+	// Defaults lists fields where built-in defaults were applied.
+	Defaults []string
 }
 
 // Validate inspects the loaded config and returns warnings about missing
@@ -244,8 +246,9 @@ type ValidationResult struct {
 func (c *Config) Validate() ValidationResult {
 	var r ValidationResult
 
-	if c.presentKeys == nil {
-		c.presentKeys = make(map[string]bool)
+	presentKeys := c.presentKeys
+	if presentKeys == nil {
+		presentKeys = make(map[string]bool)
 	}
 
 	// --- Warnings ---
@@ -272,14 +275,18 @@ func (c *Config) Validate() ValidationResult {
 	}
 
 	if c.AllowedUserIDsEnv == "" {
-		if !c.presentKeys["allowed_user_ids_env"] {
-			r.Warnings = append(r.Warnings,
-				"allowed_user_ids_env not configured — no user whitelist set")
-		}
+		r.Warnings = append(r.Warnings,
+			"allowed_user_ids_env not configured — no user whitelist set")
 	} else if len(c.AllowedUserIDs) == 0 {
 		r.Warnings = append(r.Warnings,
 			fmt.Sprintf("allowed user IDs env var %q is empty — all messages will be rejected",
 				c.AllowedUserIDsEnv))
+	}
+
+	if len(c.SystemPrompt) > 4000 {
+		r.Warnings = append(r.Warnings,
+			fmt.Sprintf("system_prompt is very long (%d chars), may consume significant context window",
+				len(c.SystemPrompt)))
 	}
 
 	// --- Defaults ---
@@ -292,12 +299,19 @@ func (c *Config) Validate() ValidationResult {
 		{"history_limit", c.HistoryLimit},
 		{"history_token_budget", c.HistoryTokenBudget},
 		{"max_document_tokens", c.MaxDocumentTokens},
-		{"max_retries", *c.MaxRetries},
-		{"max_archived_conversations", *c.MaxArchivedConversations},
-		{"log_level", c.LogLevel},
+	}
+	if c.MaxRetries != nil {
+		fields = append(fields, defaultField{"max_retries", *c.MaxRetries})
+	}
+	if c.MaxArchivedConversations != nil {
+		fields = append(fields, defaultField{"max_archived_conversations", *c.MaxArchivedConversations})
+	}
+	// Only report log_level as default if not overridden by LOG_LEVEL env var.
+	if os.Getenv("LOG_LEVEL") == "" {
+		fields = append(fields, defaultField{"log_level", c.LogLevel})
 	}
 	for _, f := range fields {
-		if !c.presentKeys[f.key] {
+		if !presentKeys[f.key] {
 			r.Defaults = append(r.Defaults,
 				fmt.Sprintf("using default %s: %v", f.key, f.value))
 		}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -355,5 +356,215 @@ func TestLoad_StatusMessages_AllCustom(t *testing.T) {
 		sm.ImageGenericErr != "d" || sm.ImageTooLarge != "e" || sm.ProvTimeout != "f" ||
 		sm.ProvAuthError != "g" || sm.ProvGenericErr != "h" {
 		t.Errorf("unexpected status messages: %+v", sm)
+	}
+}
+
+func TestValidate_FullConfig(t *testing.T) {
+	t.Setenv("TEST_TG_TOKEN", "tok123")
+	t.Setenv("TEST_API_KEY", "key456")
+	t.Setenv("TEST_ALLOWED_IDS", "111,222")
+
+	fullWithImages := `{
+		"telegram": {"token_env": "TEST_TG_TOKEN"},
+		"providers": [
+			{"name": "test-claude", "type": "claude-cli"},
+			{"name": "test-openai", "type": "openai", "base_url": "https://api.example.com", "model": "gpt-4", "api_key_env": "TEST_API_KEY"}
+		],
+		"image_providers": [
+			{"name": "test-img", "type": "chutes", "base_url": "https://img.example.com", "api_key_env": "TEST_API_KEY"}
+		],
+		"store": {"path": "/tmp/test.db"},
+		"history_limit": 30,
+		"history_token_budget": 4000,
+		"max_document_tokens": 2000,
+		"max_retries": 2,
+		"max_archived_conversations": 100,
+		"log_level": "debug",
+		"allowed_user_ids_env": "TEST_ALLOWED_IDS"
+	}`
+
+	cfg, err := Load(writeConfig(t, fullWithImages))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	result := cfg.Validate()
+	if len(result.Warnings) != 0 {
+		t.Errorf("Warnings = %v, want empty", result.Warnings)
+	}
+	if len(result.Defaults) != 0 {
+		t.Errorf("Defaults = %v, want empty", result.Defaults)
+	}
+}
+
+func TestValidate_MinimalConfig(t *testing.T) {
+	t.Setenv("TEST_TG_TOKEN", "tok123")
+	t.Setenv("TEST_ALLOWED_IDS", "111")
+
+	cfg, err := Load(writeConfig(t, `{
+		"telegram": {"token_env": "TEST_TG_TOKEN"},
+		"providers": [{"name": "c", "type": "claude-cli"}],
+		"allowed_user_ids_env": "TEST_ALLOWED_IDS"
+	}`))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	result := cfg.Validate()
+
+	found := false
+	for _, w := range result.Warnings {
+		if strings.Contains(w, "image_providers") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected warning about image_providers, got: %v", result.Warnings)
+	}
+
+	if len(result.Defaults) != 6 {
+		t.Errorf("len(Defaults) = %d, want 6; got: %v", len(result.Defaults), result.Defaults)
+	}
+}
+
+func TestValidate_EmptyProviders(t *testing.T) {
+	t.Setenv("TEST_TG_TOKEN", "tok123")
+
+	cfg, err := Load(writeConfig(t, `{
+		"telegram": {"token_env": "TEST_TG_TOKEN"},
+		"providers": []
+	}`))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	result := cfg.Validate()
+	found := false
+	for _, w := range result.Warnings {
+		if strings.Contains(w, "no providers configured") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected warning about empty providers, got: %v", result.Warnings)
+	}
+}
+
+func TestValidate_EmptyImageProviders(t *testing.T) {
+	t.Setenv("TEST_TG_TOKEN", "tok123")
+	t.Setenv("TEST_ALLOWED_IDS", "111")
+
+	cfg, err := Load(writeConfig(t, `{
+		"telegram": {"token_env": "TEST_TG_TOKEN"},
+		"providers": [{"name": "c", "type": "claude-cli"}],
+		"image_providers": [],
+		"allowed_user_ids_env": "TEST_ALLOWED_IDS"
+	}`))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	result := cfg.Validate()
+	found := false
+	for _, w := range result.Warnings {
+		if strings.Contains(w, "image generation will be unavailable") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected warning about image_providers, got: %v", result.Warnings)
+	}
+}
+
+func TestValidate_EmptyTelegramToken(t *testing.T) {
+	cfg, err := Load(writeConfig(t, `{
+		"telegram": {"token_env": "UNSET_TOKEN_VAR"},
+		"providers": [{"name": "c", "type": "claude-cli"}]
+	}`))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	result := cfg.Validate()
+	found := false
+	for _, w := range result.Warnings {
+		if strings.Contains(w, "telegram token not set") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected warning about telegram token, got: %v", result.Warnings)
+	}
+}
+
+func TestValidate_OpenAIProviderMissingKey(t *testing.T) {
+	t.Setenv("TEST_TG_TOKEN", "tok123")
+
+	cfg, err := Load(writeConfig(t, `{
+		"telegram": {"token_env": "TEST_TG_TOKEN"},
+		"providers": [
+			{"name": "no-key", "type": "openai", "base_url": "https://api.example.com", "api_key_env": "MISSING_KEY_VAR"}
+		]
+	}`))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	result := cfg.Validate()
+	found := false
+	for _, w := range result.Warnings {
+		if strings.Contains(w, "no-key") && strings.Contains(w, "API key not set") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected warning about missing API key, got: %v", result.Warnings)
+	}
+}
+
+func TestValidate_AllowedUserIDsNotConfigured(t *testing.T) {
+	t.Setenv("TEST_TG_TOKEN", "tok123")
+
+	cfg, err := Load(writeConfig(t, `{
+		"telegram": {"token_env": "TEST_TG_TOKEN"},
+		"providers": [{"name": "c", "type": "claude-cli"}]
+	}`))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	result := cfg.Validate()
+	found := false
+	for _, w := range result.Warnings {
+		if strings.Contains(w, "allowed_user_ids_env not configured") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected warning about missing allowed_user_ids_env, got: %v", result.Warnings)
+	}
+}
+
+func TestValidate_AllowedUserIDsEmptyEnv(t *testing.T) {
+	t.Setenv("TEST_TG_TOKEN", "tok123")
+	t.Setenv("EMPTY_IDS", "")
+
+	cfg, err := Load(writeConfig(t, `{
+		"telegram": {"token_env": "TEST_TG_TOKEN"},
+		"providers": [{"name": "c", "type": "claude-cli"}],
+		"allowed_user_ids_env": "EMPTY_IDS"
+	}`))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	result := cfg.Validate()
+	found := false
+	for _, w := range result.Warnings {
+		if strings.Contains(w, "EMPTY_IDS") && strings.Contains(w, "empty") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected warning about empty allowed user IDs env var, got: %v", result.Warnings)
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -421,8 +422,25 @@ func TestValidate_MinimalConfig(t *testing.T) {
 		t.Errorf("expected warning about image_providers, got: %v", result.Warnings)
 	}
 
-	if len(result.Defaults) != 6 {
-		t.Errorf("len(Defaults) = %d, want 6; got: %v", len(result.Defaults), result.Defaults)
+	wantDefaults := []string{
+		"history_limit",
+		"history_token_budget",
+		"max_document_tokens",
+		"max_retries",
+		"max_archived_conversations",
+		"log_level",
+	}
+	for _, key := range wantDefaults {
+		found := false
+		for _, d := range result.Defaults {
+			if strings.Contains(d, key) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected default for %q, got: %v", key, result.Defaults)
+		}
 	}
 }
 
@@ -566,5 +584,76 @@ func TestValidate_AllowedUserIDsEmptyEnv(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("expected warning about empty allowed user IDs env var, got: %v", result.Warnings)
+	}
+}
+
+func TestValidate_AllowedUserIDsExplicitEmptyString(t *testing.T) {
+	t.Setenv("TEST_TG_TOKEN", "tok123")
+
+	cfg, err := Load(writeConfig(t, `{
+		"telegram": {"token_env": "TEST_TG_TOKEN"},
+		"providers": [{"name": "c", "type": "claude-cli"}],
+		"allowed_user_ids_env": ""
+	}`))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	result := cfg.Validate()
+	found := false
+	for _, w := range result.Warnings {
+		if strings.Contains(w, "allowed_user_ids_env not configured") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected warning about unconfigured allowed_user_ids_env, got: %v", result.Warnings)
+	}
+}
+
+func TestValidate_LongSystemPrompt(t *testing.T) {
+	t.Setenv("TEST_TG_TOKEN", "tok123")
+
+	longPrompt := strings.Repeat("x", 4001)
+	jsonStr := fmt.Sprintf(`{
+		"telegram": {"token_env": "TEST_TG_TOKEN"},
+		"providers": [{"name": "c", "type": "claude-cli"}],
+		"system_prompt": %q
+	}`, longPrompt)
+
+	cfg, err := Load(writeConfig(t, jsonStr))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	result := cfg.Validate()
+	found := false
+	for _, w := range result.Warnings {
+		if strings.Contains(w, "system_prompt") && strings.Contains(w, "very long") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected warning about long system_prompt, got: %v", result.Warnings)
+	}
+}
+
+func TestValidate_LogLevelEnvOverrideNotDefault(t *testing.T) {
+	t.Setenv("TEST_TG_TOKEN", "tok123")
+	t.Setenv("LOG_LEVEL", "warn")
+
+	cfg, err := Load(writeConfig(t, `{
+		"telegram": {"token_env": "TEST_TG_TOKEN"},
+		"providers": [{"name": "c", "type": "claude-cli"}]
+	}`))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	result := cfg.Validate()
+	for _, d := range result.Defaults {
+		if strings.Contains(d, "log_level") {
+			t.Errorf("log_level should not appear in defaults when LOG_LEVEL env var is set, got: %v", result.Defaults)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Closes #164

- Add `Config.Validate()` method that returns `ValidationResult` with warnings (missing features, misconfigurations) and defaults (fields where defaults were applied). Uses `presentKeys` tracking to distinguish explicit values from defaults.
- Log validation results at startup in `serve()` — warnings via `slog.Warn`, defaults via `slog.Info`
- Add `herald validate-config` CLI subcommand for dry-run config checking without starting the bot

## Test Plan

- [x] 8 unit tests covering all validation scenarios (full config, minimal config, empty providers, empty image providers, empty telegram token, missing API key, missing/empty allowed user IDs)
- [x] Full test suite passes (`go test ./...`)
- [x] `go vet ./...` clean
- [x] Manual verification: `herald validate-config -c config.json.example` prints expected warnings
- [x] Manual verification: `herald validate-config -c /nonexistent` exits 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)