### PR TITLE
fix(format): bold markdown not rendered in Telegram messages

### DIFF
--- a/internal/format/telegram.go
+++ b/internal/format/telegram.go
@@ -530,13 +530,17 @@ func stripHTMLTags(s string) string {
 }
 
 // unparsedBoldRe matches **...** that goldmark left unconverted.
-var unparsedBoldRe = regexp.MustCompile(`\*\*(.+?)\*\*`)
+// The first character after ** must not be whitespace or * to avoid
+// matching lone ** markers that goldmark intentionally left as literal text.
+var unparsedBoldRe = regexp.MustCompile(`\*\*([^\s*].*?)\*\*`)
 
 // fixUnparsedBold converts remaining **...** patterns to <b>...</b>.
 // CommonMark does not treat ** as a closing delimiter when it follows
 // punctuation and is immediately followed by a Unicode letter (e.g.,
 // **word:**nextword). This post-processing step catches those cases.
-// Content inside <pre> and <code> tags is left unchanged.
+// Content inside <pre>, <code>, and <b> tags is left unchanged.
+// Inside <b> blocks (e.g., headings), ** markers are stripped rather than
+// converted, since the content is already bold.
 func fixUnparsedBold(s string) string {
 	if !strings.Contains(s, "**") {
 		return s
@@ -546,19 +550,24 @@ func fixUnparsedBold(s string) string {
 	buf.Grow(len(s))
 
 	for len(s) > 0 {
-		// Find the next <pre or <code tag.
 		preIdx := strings.Index(s, "<pre")
 		codeIdx := strings.Index(s, "<code")
+		boldIdx := strings.Index(s, "<b>")
 
 		tagIdx := -1
 		var closeTag string
+		stripOnly := false
 		switch {
-		case preIdx >= 0 && (codeIdx < 0 || preIdx < codeIdx):
+		case preIdx >= 0 && (codeIdx < 0 || preIdx <= codeIdx) && (boldIdx < 0 || preIdx <= boldIdx):
 			tagIdx = preIdx
 			closeTag = "</pre>"
-		case codeIdx >= 0:
+		case codeIdx >= 0 && (boldIdx < 0 || codeIdx <= boldIdx):
 			tagIdx = codeIdx
 			closeTag = "</code>"
+		case boldIdx >= 0:
+			tagIdx = boldIdx
+			closeTag = "</b>"
+			stripOnly = true
 		}
 
 		if tagIdx < 0 {
@@ -570,14 +579,21 @@ func fixUnparsedBold(s string) string {
 		buf.WriteString(unparsedBoldRe.ReplaceAllString(s[:tagIdx], "<b>$1</b>"))
 		s = s[tagIdx:]
 
-		// Find the matching close tag and copy the block verbatim.
+		// Find the matching close tag.
 		closeIdx := strings.Index(s, closeTag)
 		if closeIdx < 0 {
 			buf.WriteString(s)
 			break
 		}
 		closeIdx += len(closeTag)
-		buf.WriteString(s[:closeIdx])
+
+		if stripOnly {
+			// Inside <b> blocks (e.g., headings), strip ** markers
+			// instead of converting to nested <b> tags.
+			buf.WriteString(strings.ReplaceAll(s[:closeIdx], "**", ""))
+		} else {
+			buf.WriteString(s[:closeIdx])
+		}
 		s = s[closeIdx:]
 	}
 

--- a/internal/format/telegram.go
+++ b/internal/format/telegram.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"fmt"
 	"html"
+	"regexp"
 	"strings"
 
 	"github.com/yuin/goldmark"
@@ -40,7 +41,8 @@ func TelegramHTML(markdown string) string {
 		return html.EscapeString(markdown)
 	}
 
-	return strings.TrimSpace(buf.String())
+	result := strings.TrimSpace(buf.String())
+	return fixUnparsedBold(result)
 }
 
 type telegramRenderer struct{}
@@ -524,5 +526,60 @@ func stripHTMLTags(s string) string {
 			buf.WriteRune(r)
 		}
 	}
+	return buf.String()
+}
+
+// unparsedBoldRe matches **...** that goldmark left unconverted.
+var unparsedBoldRe = regexp.MustCompile(`\*\*(.+?)\*\*`)
+
+// fixUnparsedBold converts remaining **...** patterns to <b>...</b>.
+// CommonMark does not treat ** as a closing delimiter when it follows
+// punctuation and is immediately followed by a Unicode letter (e.g.,
+// **word:**nextword). This post-processing step catches those cases.
+// Content inside <pre> and <code> tags is left unchanged.
+func fixUnparsedBold(s string) string {
+	if !strings.Contains(s, "**") {
+		return s
+	}
+
+	var buf strings.Builder
+	buf.Grow(len(s))
+
+	for len(s) > 0 {
+		// Find the next <pre or <code tag.
+		preIdx := strings.Index(s, "<pre")
+		codeIdx := strings.Index(s, "<code")
+
+		tagIdx := -1
+		var closeTag string
+		switch {
+		case preIdx >= 0 && (codeIdx < 0 || preIdx < codeIdx):
+			tagIdx = preIdx
+			closeTag = "</pre>"
+		case codeIdx >= 0:
+			tagIdx = codeIdx
+			closeTag = "</code>"
+		}
+
+		if tagIdx < 0 {
+			buf.WriteString(unparsedBoldRe.ReplaceAllString(s, "<b>$1</b>"))
+			break
+		}
+
+		// Process text before the tag.
+		buf.WriteString(unparsedBoldRe.ReplaceAllString(s[:tagIdx], "<b>$1</b>"))
+		s = s[tagIdx:]
+
+		// Find the matching close tag and copy the block verbatim.
+		closeIdx := strings.Index(s, closeTag)
+		if closeIdx < 0 {
+			buf.WriteString(s)
+			break
+		}
+		closeIdx += len(closeTag)
+		buf.WriteString(s[:closeIdx])
+		s = s[closeIdx:]
+	}
+
 	return buf.String()
 }

--- a/internal/format/telegram_test.go
+++ b/internal/format/telegram_test.go
@@ -29,6 +29,48 @@ func TestTelegramHTML_Bold(t *testing.T) {
 	}
 }
 
+func TestTelegramHTML_BoldNoSpaceAfterClosing(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "bold colon no space",
+			in:   "**Bianka:**Nasza koteczka",
+			want: "<b>Bianka:</b>Nasza koteczka",
+		},
+		{
+			name: "multiple bold colon no space",
+			in:   "**Bianka:**kot\n**Homelab:**serwer\n**Gaming:**gra",
+			want: "<b>Bianka:</b>kot\n<b>Homelab:</b>serwer\n<b>Gaming:</b>gra",
+		},
+		{
+			name: "bold no space preserved in code block",
+			in:   "```\n**not bold:**here\n```",
+			want: "<pre><code>**not bold:**here\n</code></pre>",
+		},
+		{
+			name: "bold no space preserved in inline code",
+			in:   "use `**not bold:**here` ok",
+			want: "use <code>**not bold:**here</code> ok",
+		},
+		{
+			name: "normal bold still works",
+			in:   "**Bianka:** kot",
+			want: "<b>Bianka:</b> kot",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := TelegramHTML(tt.in)
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestTelegramHTML_Italic(t *testing.T) {
 	got := TelegramHTML("This is *italic* text")
 	want := "This is <i>italic</i> text"

--- a/internal/format/telegram_test.go
+++ b/internal/format/telegram_test.go
@@ -60,6 +60,16 @@ func TestTelegramHTML_BoldNoSpaceAfterClosing(t *testing.T) {
 			in:   "**Bianka:** kot",
 			want: "<b>Bianka:</b> kot",
 		},
+		{
+			name: "heading with unparsed bold no nesting",
+			in:   "# **Title:**content",
+			want: "<b>Title:content</b>",
+		},
+		{
+			name: "lone double asterisks not converted",
+			in:   "Use ** for emphasis **word:**next",
+			want: "Use ** for emphasis <b>word:</b>next",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fix bold markdown (`**text**`) showing as raw asterisks in Telegram messages when the closing `**` follows punctuation and is immediately followed by a Unicode letter (e.g., `**Bianka:**Nasza`)
- Root cause: CommonMark spec treats `**` after punctuation + before letter as not right-flanking, so goldmark doesn't close the emphasis
- Add `fixUnparsedBold` post-processing step that converts remaining `**...**` to `<b>...</b>` after goldmark, preserving literal `**` inside `<pre>` and `<code>` tags

Closes #175

## Test plan

- [x] New test `TestTelegramHTML_BoldNoSpaceAfterClosing` with 5 subtests covering:
  - `**word:**word` pattern (the bug)
  - Multiple bold labels without spaces
  - `**` preserved inside fenced code blocks
  - `**` preserved inside inline code
  - Normal bold with space still works
- [x] All 43 existing format tests pass
- [x] Full test suite passes (`go test ./...`)
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)